### PR TITLE
RealM을 연동하여 못먹는음식 데이터를 Local DB에 저장합니다.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
 - legacy_constructor
 - force_cast
 - trailing_comma
+- force_try
 
 file_length: 500
 type_body_length: 250

--- a/WhatWeEat.xcodeproj/project.pbxproj
+++ b/WhatWeEat.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		3636DE94283C870800F04111 /* DislikedFoodSurveyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DE93283C870800F04111 /* DislikedFoodSurveyViewController.swift */; };
 		3636DE96283CCFD000F04111 /* AlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DE95283CCFD000F04111 /* AlertFactory.swift */; };
 		3636DE99283CF98800F04111 /* DislikedFoodSurveyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DE98283CF98800F04111 /* DislikedFoodSurveyViewModel.swift */; };
+		3636DE9C283DFE2300F04111 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3636DE9B283DFE2300F04111 /* RealmSwift */; };
+		3636DEA2283E00FE00F04111 /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEA1283E00FE00F04111 /* RealmManager.swift */; };
+		3636DEA5283E068B00F04111 /* DislikedFoodForRealm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEA4283E068B00F04111 /* DislikedFoodForRealm.swift */; };
 		DE095C85283B241A00C7E109 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DE095C84283B241A00C7E109 /* RxCocoa */; };
 		DE095C87283B241A00C7E109 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DE095C86283B241A00C7E109 /* RxSwift */; };
 		DE69461B283C6ADC00BAA51D /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69461A283C6ADC00BAA51D /* OnboardingViewModel.swift */; };
@@ -51,6 +54,8 @@
 		3636DE93283C870800F04111 /* DislikedFoodSurveyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DislikedFoodSurveyViewController.swift; sourceTree = "<group>"; };
 		3636DE95283CCFD000F04111 /* AlertFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertFactory.swift; sourceTree = "<group>"; };
 		3636DE98283CF98800F04111 /* DislikedFoodSurveyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DislikedFoodSurveyViewModel.swift; sourceTree = "<group>"; };
+		3636DEA1283E00FE00F04111 /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
+		3636DEA4283E068B00F04111 /* DislikedFoodForRealm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DislikedFoodForRealm.swift; sourceTree = "<group>"; };
 		DE69461A283C6ADC00BAA51D /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		DE69461C283CD1A700BAA51D /* DislikedFoodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DislikedFoodCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -60,6 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3636DE9C283DFE2300F04111 /* RealmSwift in Frameworks */,
 				DE095C87283B241A00C7E109 /* RxSwift in Frameworks */,
 				DE095C85283B241A00C7E109 /* RxCocoa in Frameworks */,
 			);
@@ -99,6 +105,7 @@
 			children = (
 				DE095C88283B259300C7E109 /* App */,
 				DE095C89283B259D00C7E109 /* Presentation */,
+				3636DE9E283E00CA00F04111 /* Data */,
 				3636DE8E283B5D2600F04111 /* Utility */,
 				DE095C8A283B25AD00C7E109 /* Resource */,
 				3636DE62283B225200F04111 /* Info.plist */,
@@ -175,6 +182,31 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		3636DE9E283E00CA00F04111 /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				3636DE9F283E00E300F04111 /* LocalDB */,
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+		3636DE9F283E00E300F04111 /* LocalDB */ = {
+			isa = PBXGroup;
+			children = (
+				3636DEA3283E067900F04111 /* Entity */,
+				3636DEA1283E00FE00F04111 /* RealmManager.swift */,
+			);
+			path = LocalDB;
+			sourceTree = "<group>";
+		};
+		3636DEA3283E067900F04111 /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+				3636DEA4283E068B00F04111 /* DislikedFoodForRealm.swift */,
+			);
+			path = Entity;
+			sourceTree = "<group>";
+		};
 		DE095C88283B259300C7E109 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -222,6 +254,7 @@
 			packageProductDependencies = (
 				DE095C84283B241A00C7E109 /* RxCocoa */,
 				DE095C86283B241A00C7E109 /* RxSwift */,
+				3636DE9B283DFE2300F04111 /* RealmSwift */,
 			);
 			productName = WhatWeEat;
 			productReference = 3636DE51283B225100F04111 /* WhatWeEat.app */;
@@ -275,6 +308,7 @@
 			mainGroup = 3636DE48283B225100F04111;
 			packageReferences = (
 				DE095C83283B241A00C7E109 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				3636DE9A283DFE2300F04111 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = 3636DE52283B225100F04111 /* Products */;
 			projectDirPath = "";
@@ -333,6 +367,8 @@
 			files = (
 				3636DE8D283B561A00F04111 /* OnboardingContentViewController.swift in Sources */,
 				DE69461B283C6ADC00BAA51D /* OnboardingViewModel.swift in Sources */,
+				3636DEA5283E068B00F04111 /* DislikedFoodForRealm.swift in Sources */,
+				3636DEA2283E00FE00F04111 /* RealmManager.swift in Sources */,
 				3636DE8B283B55D300F04111 /* OnboardingPageViewController.swift in Sources */,
 				DE69461D283CD1A700BAA51D /* DislikedFoodCell.swift in Sources */,
 				3636DE55283B225100F04111 /* AppDelegate.swift in Sources */,
@@ -615,6 +651,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3636DE9A283DFE2300F04111 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/realm-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = 10.26.0;
+			};
+		};
 		DE095C83283B241A00C7E109 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
@@ -626,6 +670,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3636DE9B283DFE2300F04111 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3636DE9A283DFE2300F04111 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
 		DE095C84283B241A00C7E109 /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DE095C83283B241A00C7E109 /* XCRemoteSwiftPackageReference "RxSwift" */;

--- a/WhatWeEat/Data/LocalDB/Entity/DislikedFoodForRealm.swift
+++ b/WhatWeEat/Data/LocalDB/Entity/DislikedFoodForRealm.swift
@@ -1,0 +1,12 @@
+import Foundation
+import RealmSwift
+
+// TODO: Remote 서버에 못먹는음식 데이터 보낼 때, Model 타입 확인
+class DislikedFoodForRealM: Object {
+    @Persisted var name: String
+    
+    convenience init(name: String) {
+        self.init()
+        self.name = name
+    }
+}

--- a/WhatWeEat/Data/LocalDB/RealmManager.swift
+++ b/WhatWeEat/Data/LocalDB/RealmManager.swift
@@ -1,0 +1,9 @@
+import Foundation
+import RealmSwift
+
+struct RealmManager {
+    static var shared = RealmManager()
+    let realm = try! Realm()
+    
+    private init() { }
+}

--- a/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodCell.swift
+++ b/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodCell.swift
@@ -1,5 +1,5 @@
 import UIKit
-import WebKit
+import RealmSwift
 
 final class DislikedFoodCell: UICollectionViewCell {
     // MARK: - Nested Types

--- a/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodSurveyViewController.swift
+++ b/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodSurveyViewController.swift
@@ -153,13 +153,15 @@ extension DislikedFoodSurveyViewController {
     private func bind() {
         let input = DislikedFoodSurveyViewModel.Input(
             invokedViewDidLoad: invokedViewDidLoad.asObservable(),
-            cellDidSelect: collectionView.rx.itemSelected.asObservable()
+            cellDidSelect: collectionView.rx.itemSelected.asObservable(),
+            confirmButtonDidTap: confirmButton.rx.tap.asObservable()
         )
         
         let output = viewModel.transform(input)
         
         configureItems(with: output.dislikedFoods)
         configureSelectedCell(at: output.selectedFoodIndexPath)
+        configureConfirmButtonDidTap(with: output.confirmButtonDidTap)
     }
 
     private func configureItems(with dislikedFoods: Observable<[DislikedFoodCell.DislikedFood]>) {
@@ -184,6 +186,15 @@ extension DislikedFoodSurveyViewController {
             .subscribe(onNext: { [weak self] indexPath in
                 guard let selectedCell = self?.collectionView.cellForItem(at: indexPath) as? DislikedFoodCell else { return }
                 selectedCell.toggleSelectedCellUI()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func configureConfirmButtonDidTap(with confirmButtonDidTap: Observable<Void>) {
+        confirmButtonDidTap
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: {
+                // TODO: didTap 받아서 화면이동
             })
             .disposed(by: disposeBag)
     }

--- a/WhatWeEat/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/WhatWeEat/Presentation/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -6,18 +6,21 @@ final class OnboardingViewModel {
     struct Input {
         let currentIndexForPreviousPage: Observable<Int>
         let currentIndexForNextPageAndPageCount: Observable<(Int, Int)>
+        let skipButtonDidTap: Observable<Void>
     }
     
     struct Output {
         let previousPageIndex: Observable<Int?>
         let nextPageIndex: Observable<Int?>
+        let skipButtonDidTap: Observable<Void>
     }
     
     // MARK: - Methods
     func transform(_ input: Input) -> Output {
         let previousPageIndex = configurePreviousPageIndexObservable(by: input.currentIndexForPreviousPage)
         let nextPageIndex = configureNextPageIndexObservable(by: input.currentIndexForNextPageAndPageCount)
-        let output = Output(previousPageIndex: previousPageIndex, nextPageIndex: nextPageIndex)
+        let skipButtonDidTap = configureSkipButtonDidTapObservable(by: input.skipButtonDidTap)
+        let output = Output(previousPageIndex: previousPageIndex, nextPageIndex: nextPageIndex, skipButtonDidTap: skipButtonDidTap)
         
         return output
     }
@@ -40,5 +43,9 @@ final class OnboardingViewModel {
                 return Observable.just(nil)
             }
         }
+    }
+    
+    private func configureSkipButtonDidTapObservable(by inputObserver: Observable<Void>) -> Observable<Void> {
+        return inputObserver
     }
 }


### PR DESCRIPTION
# 배경
`OnboardingPage`에서 사용자가 제출한 못먹는음식 데이터를 Loacl DB에 저장하기 위해 Realm을 사용했습니다.

# 작업 내용
## 1. Local DB 선택
### Local DB 비교
아래와 같이 RealM, SQLite, CoreData 3개 DB를 비교한 결과, RealM을 채택했습니다.

|DB|[Realm ✅](https://github.com/realm/realm-swift)|[SQLite](https://github.com/sqlite/sqlite)|[CoreData](https://developer.apple.com/documentation/coredata)|
|-|-|-|-|
|특징|- 모바일에 최적화된 *NoSQL DB 라이브러리로 가장 최근에 등장함</br>*NoSQL (Not Only SQL) : SQL 외 여러 유형의 DB를 사용함</br>- 데이터 객체가 Objective-C 클래스로 표현되며, 가볍고 반응형임</br>- *데이터 컨테이너 모델을 사용함</br>*컨테이너 : OS상의 논리적인 구획(컨테이너)을 만들고, 앱 실행에 필요한 라이브러리/앱을 하나로 모아, 별도 서버처럼 사용하도록 만든 구조. 컨테이너는 오버헤드가 적으므로 가볍고 속도가 빠름</br>- Swift, Objective-C, Java, Kotlin, C#, JavaScript 등의 SDK를 제공|- 전세계적으로 가장 많이 사용되는 SQL DB 라이브러리</br>- 전통적인 테이블 지향 관계형 DB</br>*ORM (Object Relational Mapping) : OOP의 “객체” 및 관계형 DB의 데이터인 “테이블”을 매핑하는 구조</br>- [단일 사용자의 데이터를 저장하는 로컬 앱에 적합](https://smoh.tistory.com/368)|- 앱의 Model layer를 관리하기 위한 Apple의 First-party FrameWork (DB가 아님) </br>- Persistence 기능은 SQLite에 의해 지원됨 </br>- ORM 모델을 추상화한 구조
|장점|- [SQLite 및 CoreData 대비 작업 속도가 빠름](https://hackernoon.com/sqlite-vs-realm-which-database-to-choose-in-2021-8g1v3wf9)</br>- 하나의 앱에서 여러 DB를 사용 가능</br>- 데이터를 객체 형태로 저장하여 DB에서 가져온 데이터를 앱에 즉시 사용 가능하고, CoreData 코드를 Realm으로 Migration하기 용이함</br>- 데이터 저장 용량이 무제한/무료</br>- iOS 및 Android 간의 DB 공유 가능</br>- Realm Studio를 통해 Finder로 DB 확인이 쉬움</br>- CoreData 대비 직관적인 코드</br>- DB 처리에 Main Thread를 사용하므로 안정적임 (장점이자 단점)|- C언어로 작성되어 가벼우며, 전체 DB를 디스크 파일 1개에 저장</br>- 설정이 쉬움</br>- Thread-safe</br>- 다양한 OS에서 사용 가능 (MacOS X, iOS, Android, Window, Linux)|- 데이터를 객체 (NSManagedObject) 형태로 저장하여 DB에서 가져온 데이터를 앱에 즉시 사용 가능 </br>- SQLite 대비 속도가 빠름
|단점|- Thread-confined함 (스레드별 객체 관리가 필요. 다른 스레드로 전달하려면 wrapper 등이 필요)</br>- SQLite 대비 바이너리 용량이 큼</br>- 다양한 query를 지원하지 않음|- 동시성 (Concurrency)에 제한이 있음 (여러 프로세스가 DB에 접근/quering이 가능하지만, 한 번에 1개 프로세스만 처리 가능)</br>- 데이터 용량이 큰 경우 부적합</br>- 접근 권한 종류가 한 가지 밖에 없음|- 사용이 직관적이지 않고 번거로움 (Entity 생성, 코드로 데이터를 Read/Write 등)</br>- 메모리 및 저장공간 소모가 큼 (In-memory 방식은 메모리에 로딩된 객체만 수정 가능)</br>- 데이터 중복을 방지하는 unique key 기능이 없음</br>- Thread-unsafe</br>- 오버헤드 발생 가능</br>- Android 등 크로스 플랫폼을 지원하지 않음|

### 기술스택 고려사항
1. 하위 버전 호환성에는 문제가 없는가?
    - Deployment Target을 iOS 14이상으로 설정할 계획이고, Xcode 버전 13.4을 사용 중이므로 문제 없습니다.
    - Realm : [SPM 사용 기준 iOS 11 이상](https://docs.mongodb.com/realm/sdk/swift/install/)
2. 안정적으로 운용 가능한가?
    - 모바일에 최적화되어 있으므로 iOS를 지속 지원할 것으로 예상되며, [2.0 버전부터 안정화](https://www.theteams.kr/teams/859/post/64925)됐다고 판단했습니다.
3. 미래 지속가능성이 있는가?
    - 지속적으로 기능이 업데이트되고 있습니다.
    - 서비스를 확장하여 Android 앱을 개발할 경우에도 사용할 수 있습니다.
4. 리스크를 최소화 할 수 있는가? 알고있는 리스크는 무엇인가?
    - First-party 라이브러리가 아니므로 서비스가 중단될 리스크가 있지만, 중단될 가능성이 낮다고 판단했습니다.
    - Realm은 Thread별 객체 관리가 필요하며, 바이너리 용량이 크므로 지속적으로 Thread/용량을 관리할 필요가 있습니다. 또한 현재 용량 무제한/무료이지만 가격 정책이 변경될 수 있습니다.
5. 어떤 의존성 관리도구를 사용하여 관리할 수 있는가?
    - Cocoa Pods, Carthage, SPM을 사용할 수 있습니다.
    - First-party 라이브러리인 SPM을 사용중이므로 적합합니다.

## 2. RealM 연동
싱글톤 패턴을 적용하여 RealmManager 타입을 생성하고, realm 객체를 가지도록 했습니다. 또한 RealM 데이터 저장을 위한 객체 타입으로 `DislikedFoodForRealM` 타입을 추가했습니다.

`OnboardingPage`의 못먹는음식 화면에서 `확인 버튼`을 Tap하는 이벤트를 받을 때마다, RealM에 못먹는음식 데이터를 업데이트 (기존 데이터 전체삭제, 새로운 데이터 추가)하도록 구현했습니다.

## 3. Skip 버튼 구현
1, 2 페이지에서 Skip 버튼을 Tap한 경우, 바로 못먹는음식 페이지로 이동하도록 했습니다.

`UIPageViewController`의 `setViewControllers` 메서드를 활용하여 못먹는음식 페이지로 이동하도록 했고, 이 경우 기존 `pageControl`과 `Skip` 버튼이 사라지도록 했습니다.

# 테스트 방법
`RealM Studio` 맥앱을 활용해 RealM 데이터가 정상적으로 저장되는지 확인했습니다. 
데이터 저장 경로의 경우 다음과 같은 방법으로 찾았습니다. 
```swift
Realm.Configuration.defaultConfiguration.fileURL
```

- RealM Studio에 저장된 데이터 확인
![realm연동](https://user-images.githubusercontent.com/70856586/170211528-95fa81a4-abfd-458b-b27d-c85f29c3d6b8.gif)

# 리뷰 노트
- UserDefault를 통해 앱을 처음 실행하는 것이 아니라면 바로 메인 메뉴로 이동할 수 있도록 구현할 예정입니다.

# 스크린샷
<img src = "https://user-images.githubusercontent.com/70856586/170210867-5d5b873c-15f4-4de7-9601-1cb5ba98a677.gif" width="200">