### PR TITLE
네트워크를 구현하여 홈 탭 및 함께메뉴결정 탭에 서버 데이터를 반영합니다.

### DIFF
--- a/WhatWeEat.xcodeproj/project.pbxproj
+++ b/WhatWeEat.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		3636DEC1284452E300F04111 /* SharePinNumberPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC0284452E300F04111 /* SharePinNumberPageViewController.swift */; };
 		3636DEC328448A7200F04111 /* SharePinNumberPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC228448A7200F04111 /* SharePinNumberPageViewModel.swift */; };
 		3636DEC62844ACD900F04111 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC52844ACD900F04111 /* NetworkProvider.swift */; };
-		3636DEC82844AD3000F04111 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC72844AD3000F04111 /* URLSessionProtocol.swift */; };
 		3636DECA2844AD3900F04111 /* BaseURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC92844AD3900F04111 /* BaseURLProtocol.swift */; };
 		3636DECC2844AD4B00F04111 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DECB2844AD4B00F04111 /* APIProtocol.swift */; };
 		3636DECF2844AD8300F04111 /* URLRequest+Initializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DECE2844AD8300F04111 /* URLRequest+Initializer.swift */; };
@@ -90,7 +89,6 @@
 		3636DEC0284452E300F04111 /* SharePinNumberPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePinNumberPageViewController.swift; sourceTree = "<group>"; };
 		3636DEC228448A7200F04111 /* SharePinNumberPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePinNumberPageViewModel.swift; sourceTree = "<group>"; };
 		3636DEC52844ACD900F04111 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
-		3636DEC72844AD3000F04111 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
 		3636DEC92844AD3900F04111 /* BaseURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseURLProtocol.swift; sourceTree = "<group>"; };
 		3636DECB2844AD4B00F04111 /* APIProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
 		3636DECE2844AD8300F04111 /* URLRequest+Initializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest+Initializer.swift"; sourceTree = "<group>"; };
@@ -293,7 +291,6 @@
 			children = (
 				3636DEB0283E324F00F04111 /* OnboardingContentProtocol.swift */,
 				3636DEB4283F1D5F00F04111 /* TabBarContentProtocol.swift */,
-				3636DEC72844AD3000F04111 /* URLSessionProtocol.swift */,
 				3636DEC92844AD3900F04111 /* BaseURLProtocol.swift */,
 				3636DECB2844AD4B00F04111 /* APIProtocol.swift */,
 			);
@@ -557,7 +554,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3636DEC82844AD3000F04111 /* URLSessionProtocol.swift in Sources */,
 				3636DEC1284452E300F04111 /* SharePinNumberPageViewController.swift in Sources */,
 				3636DEC328448A7200F04111 /* SharePinNumberPageViewModel.swift in Sources */,
 				3636DEC62844ACD900F04111 /* NetworkProvider.swift in Sources */,

--- a/WhatWeEat.xcodeproj/project.pbxproj
+++ b/WhatWeEat.xcodeproj/project.pbxproj
@@ -31,6 +31,16 @@
 		3636DEBF283F75F900F04111 /* SoloMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEBE283F75F900F04111 /* SoloMenuViewController.swift */; };
 		3636DEC1284452E300F04111 /* SharePinNumberPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC0284452E300F04111 /* SharePinNumberPageViewController.swift */; };
 		3636DEC328448A7200F04111 /* SharePinNumberPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC228448A7200F04111 /* SharePinNumberPageViewModel.swift */; };
+		3636DEC62844ACD900F04111 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC52844ACD900F04111 /* NetworkProvider.swift */; };
+		3636DEC82844AD3000F04111 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC72844AD3000F04111 /* URLSessionProtocol.swift */; };
+		3636DECA2844AD3900F04111 /* BaseURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEC92844AD3900F04111 /* BaseURLProtocol.swift */; };
+		3636DECC2844AD4B00F04111 /* APIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DECB2844AD4B00F04111 /* APIProtocol.swift */; };
+		3636DECF2844AD8300F04111 /* URLRequest+Initializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DECE2844AD8300F04111 /* URLRequest+Initializer.swift */; };
+		3636DED12844ADFD00F04111 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DED02844ADFD00F04111 /* JSONParser.swift */; };
+		3636DED42844AE3600F04111 /* WhatWeEatURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DED32844AE3600F04111 /* WhatWeEatURL.swift */; };
+		3636DED62844B00000F04111 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DED52844B00000F04111 /* Menu.swift */; };
+		3636DED82844B06C00F04111 /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DED72844B06C00F04111 /* GameResult.swift */; };
+		3636DEDB2844CA7D00F04111 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEDA2844CA7D00F04111 /* HomeViewModel.swift */; };
 		DE095C85283B241A00C7E109 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DE095C84283B241A00C7E109 /* RxCocoa */; };
 		DE095C87283B241A00C7E109 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DE095C86283B241A00C7E109 /* RxSwift */; };
 		DE31032A283F6446009CA7C3 /* FirstLaunchChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE310329283F6446009CA7C3 /* FirstLaunchChecker.swift */; };
@@ -79,6 +89,16 @@
 		3636DEBE283F75F900F04111 /* SoloMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoloMenuViewController.swift; sourceTree = "<group>"; };
 		3636DEC0284452E300F04111 /* SharePinNumberPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePinNumberPageViewController.swift; sourceTree = "<group>"; };
 		3636DEC228448A7200F04111 /* SharePinNumberPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePinNumberPageViewModel.swift; sourceTree = "<group>"; };
+		3636DEC52844ACD900F04111 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
+		3636DEC72844AD3000F04111 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
+		3636DEC92844AD3900F04111 /* BaseURLProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseURLProtocol.swift; sourceTree = "<group>"; };
+		3636DECB2844AD4B00F04111 /* APIProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIProtocol.swift; sourceTree = "<group>"; };
+		3636DECE2844AD8300F04111 /* URLRequest+Initializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLRequest+Initializer.swift"; sourceTree = "<group>"; };
+		3636DED02844ADFD00F04111 /* JSONParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
+		3636DED32844AE3600F04111 /* WhatWeEatURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatWeEatURL.swift; sourceTree = "<group>"; };
+		3636DED52844B00000F04111 /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
+		3636DED72844B06C00F04111 /* GameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResult.swift; sourceTree = "<group>"; };
+		3636DEDA2844CA7D00F04111 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		DE310329283F6446009CA7C3 /* FirstLaunchChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstLaunchChecker.swift; sourceTree = "<group>"; };
 		DE31032C283F802E009CA7C3 /* TogetherMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogetherMenuViewController.swift; sourceTree = "<group>"; };
 		DE310330283F84D4009CA7C3 /* TogetherMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogetherMenuViewModel.swift; sourceTree = "<group>"; };
@@ -136,6 +156,7 @@
 				3636DE9E283E00CA00F04111 /* Data */,
 				3636DE8E283B5D2600F04111 /* Utility */,
 				3636DEAF283E322A00F04111 /* Protocol */,
+				3636DECD2844AD6100F04111 /* Extension */,
 				DE095C8A283B25AD00C7E109 /* Resource */,
 				3636DE62283B225200F04111 /* Info.plist */,
 			);
@@ -179,6 +200,7 @@
 		3636DE8E283B5D2600F04111 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				3636DED02844ADFD00F04111 /* JSONParser.swift */,
 				3636DE8F283B5D6800F04111 /* ColorPalette.swift */,
 				3636DE95283CCFD000F04111 /* AlertFactory.swift */,
 			);
@@ -215,6 +237,7 @@
 		3636DE9E283E00CA00F04111 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				3636DEC42844ACBC00F04111 /* RemoteDB */,
 				3636DE9F283E00E300F04111 /* LocalDB */,
 			);
 			path = Data;
@@ -260,6 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				3636DEA7283E1A4600F04111 /* View */,
+				3636DED92844CA5F00F04111 /* ViewModel */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -269,6 +293,9 @@
 			children = (
 				3636DEB0283E324F00F04111 /* OnboardingContentProtocol.swift */,
 				3636DEB4283F1D5F00F04111 /* TabBarContentProtocol.swift */,
+				3636DEC72844AD3000F04111 /* URLSessionProtocol.swift */,
+				3636DEC92844AD3900F04111 /* BaseURLProtocol.swift */,
+				3636DECB2844AD4B00F04111 /* APIProtocol.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -287,6 +314,41 @@
 				3636DEBE283F75F900F04111 /* SoloMenuViewController.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		3636DEC42844ACBC00F04111 /* RemoteDB */ = {
+			isa = PBXGroup;
+			children = (
+				3636DEC52844ACD900F04111 /* NetworkProvider.swift */,
+				3636DED32844AE3600F04111 /* WhatWeEatURL.swift */,
+				3636DED22844AE0D00F04111 /* Entity */,
+			);
+			path = RemoteDB;
+			sourceTree = "<group>";
+		};
+		3636DECD2844AD6100F04111 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				3636DECE2844AD8300F04111 /* URLRequest+Initializer.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		3636DED22844AE0D00F04111 /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+				3636DED52844B00000F04111 /* Menu.swift */,
+				3636DED72844B06C00F04111 /* GameResult.swift */,
+			);
+			path = Entity;
+			sourceTree = "<group>";
+		};
+		3636DED92844CA5F00F04111 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				3636DEDA2844CA7D00F04111 /* HomeViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		DE095C88283B259300C7E109 /* App */ = {
@@ -495,8 +557,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3636DEC82844AD3000F04111 /* URLSessionProtocol.swift in Sources */,
 				3636DEC1284452E300F04111 /* SharePinNumberPageViewController.swift in Sources */,
 				3636DEC328448A7200F04111 /* SharePinNumberPageViewModel.swift in Sources */,
+				3636DEC62844ACD900F04111 /* NetworkProvider.swift in Sources */,
 				3636DE8D283B561A00F04111 /* OnboardingContentViewController.swift in Sources */,
 				DE31032A283F6446009CA7C3 /* FirstLaunchChecker.swift in Sources */,
 				DE31032D283F802E009CA7C3 /* TogetherMenuViewController.swift in Sources */,
@@ -509,17 +573,25 @@
 				3636DEA2283E00FE00F04111 /* RealmManager.swift in Sources */,
 				3636DE8B283B55D300F04111 /* OnboardingPageViewController.swift in Sources */,
 				DE310331283F84D4009CA7C3 /* TogetherMenuViewModel.swift in Sources */,
+				3636DECA2844AD3900F04111 /* BaseURLProtocol.swift in Sources */,
 				DE310333283F8673009CA7C3 /* TogetherMenuViewModelAction.swift in Sources */,
+				3636DED42844AE3600F04111 /* WhatWeEatURL.swift in Sources */,
+				3636DEDB2844CA7D00F04111 /* HomeViewModel.swift in Sources */,
+				3636DED12844ADFD00F04111 /* JSONParser.swift in Sources */,
 				3636DEAC283E1B9900F04111 /* HomeViewController.swift in Sources */,
 				DE69461D283CD1A700BAA51D /* DislikedFoodCell.swift in Sources */,
 				3636DE55283B225100F04111 /* AppDelegate.swift in Sources */,
 				3636DEAA283E1B2C00F04111 /* MainTabBarController.swift in Sources */,
+				3636DECF2844AD8300F04111 /* URLRequest+Initializer.swift in Sources */,
 				3636DEB1283E324F00F04111 /* OnboardingContentProtocol.swift in Sources */,
 				3636DE94283C870800F04111 /* DislikedFoodSurveyViewController.swift in Sources */,
 				3636DE96283CCFD000F04111 /* AlertFactory.swift in Sources */,
 				3636DE99283CF98800F04111 /* DislikedFoodSurveyViewModel.swift in Sources */,
+				3636DED82844B06C00F04111 /* GameResult.swift in Sources */,
 				DE51DC0A2844984C000FE0CB /* SharePinNumberActivityItemSource.swift in Sources */,
+				3636DED62844B00000F04111 /* Menu.swift in Sources */,
 				3636DE57283B225100F04111 /* SceneDelegate.swift in Sources */,
+				3636DECC2844AD4B00F04111 /* APIProtocol.swift in Sources */,
 				3636DE90283B5D6800F04111 /* ColorPalette.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WhatWeEat/App/AppDelegate.swift
+++ b/WhatWeEat/App/AppDelegate.swift
@@ -6,44 +6,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-    
-    // 다른앱에서 URL을 클릭하면 호출됨
-    func application(_ app: UIApplication,
-                     open url: URL,
-                     options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        // Determine who sent the URL.
-        let sendingAppID = options[.sourceApplication]
-        print("source application = \(sendingAppID ?? "Unknown")")
-
-        // Process the URL.
-        guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
-            let path = components.path,
-            let params = components.queryItems else {
-                print("Invalid URL or PIN Number path missing")
-                return false
-        }
-        
-        if let pinNumber = params.first(where: { $0.name == "pinNumber" })?.value {
-            print("path = \(path)")
-            print("pinNumber = \(pinNumber)")
-            return true
-        } else {
-            print("Group not found")
-            return false
-        }
     }
 }

--- a/WhatWeEat/Data/RemoteDB/Entity/GameResult.swift
+++ b/WhatWeEat/Data/RemoteDB/Entity/GameResult.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct GameResult {
+    let menus: [Menu]
+    let playerCount: Int
+}

--- a/WhatWeEat/Data/RemoteDB/Entity/Menu.swift
+++ b/WhatWeEat/Data/RemoteDB/Entity/Menu.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Menu: Codable {
+    let name: String
+    let imageURL: String
+    let keywords: [String]? // TODO: enum으로 구분? 서버 협의 필요
+}

--- a/WhatWeEat/Data/RemoteDB/NetworkProvider.swift
+++ b/WhatWeEat/Data/RemoteDB/NetworkProvider.swift
@@ -1,0 +1,92 @@
+import Foundation
+import RxSwift
+
+enum NetworkError: Error, LocalizedError {
+    case statusCodeError
+    case unknownError
+    case urlIsNil
+    
+    var errorDescription: String? {
+        switch self {
+        case .statusCodeError:
+            return "정상적인 StatusCode가 아닙니다."
+        case .unknownError:
+            return "알수 없는 에러가 발생했습니다."
+        case .urlIsNil:
+            return "정상적인 URL이 아닙니다."
+        }
+    }
+}
+
+struct NetworkProvider {
+    private let session: URLSessionProtocol
+    private let disposeBag = DisposeBag()
+    
+    init(session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
+    }
+    
+    func fetchData<T: Codable>(api: Gettable, decodingType: T.Type) -> Observable<T> {
+        return Observable.create { emitter in
+            guard let task = dataTask(api: api, emitter: emitter) else {
+                return Disposables.create()
+            }
+            task.resume()
+            
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+    
+    func request(api: Postable) -> Observable<Data> {
+        return Observable.create { emitter in
+            guard let task = dataTask(api: api, emitter: emitter) else {
+                return Disposables.create()
+            }
+            task.resume()
+            
+            return Disposables.create {
+                task.cancel()
+            }
+        }
+    }
+    
+    private func dataTask<T: Codable>(api: APIProtocol, emitter: AnyObserver<T>) -> URLSessionDataTask? {
+        guard let urlRequest = URLRequest(api: api) else {
+            emitter.onError(NetworkError.urlIsNil)
+            return nil
+        }
+        
+        let task = session.dataTask(with: urlRequest) { data, response, _ in
+            let successStatusCode = 200..<300
+            guard let httpResponse = response as? HTTPURLResponse,
+                  successStatusCode.contains(httpResponse.statusCode) else {
+                emitter.onError(NetworkError.statusCodeError)
+                return
+            }
+            
+            switch api {
+            case is Gettable:
+                if let data = data {
+                    guard let decodedData = JSONParser<T>().decode(from: data) else {
+                        emitter.onError(JSONParserError.decodingFail)
+                        return
+                    }
+                    
+                    emitter.onNext(decodedData)
+                }
+            case is Postable:
+                if let data = data as? T {
+                    emitter.onNext(data)
+                }
+            default:
+                return
+            }
+            
+            emitter.onCompleted()
+        }
+        
+        return task
+    }
+}

--- a/WhatWeEat/Data/RemoteDB/WhatWeEatURL.swift
+++ b/WhatWeEat/Data/RemoteDB/WhatWeEatURL.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct WhatWeEatBaseURL: BaseURLProtocol {
+    let baseURL: String = "http://localhost:8080/"  // TODO: 추가
+}
+
+struct RandomMenuAPI: Gettable {
+    let url: URL?
+    let method: HttpMethod = .get
+    
+    init(baseURL: BaseURLProtocol = WhatWeEatBaseURL()) {
+        self.url = URL(string: "\(baseURL.baseURL)menu/random")
+    }
+}
+
+struct CreateGroupAPI: Postable {
+    let url: URL?
+    let method: HttpMethod = .post
+    var identifier: String?
+    var contentType: String?
+    var body: Data?
+    
+    init(baseURL: BaseURLProtocol = WhatWeEatBaseURL()) {
+        self.url = URL(string: "\(baseURL.baseURL)group")
+    }
+}

--- a/WhatWeEat/Extension/URLRequest+Initializer.swift
+++ b/WhatWeEat/Extension/URLRequest+Initializer.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension URLRequest {
+    init?(api: APIProtocol) {
+        guard let url = api.url else {
+            return nil
+        }
+        
+        self.init(url: url)
+        self.httpMethod = "\(api.method)"
+        
+        if let postableAPI = api as? Postable {
+            self.addValue(postableAPI.identifier ?? "", forHTTPHeaderField: "identifier")
+            self.addValue(postableAPI.contentType ?? "", forHTTPHeaderField: "Content-Type")
+            self.httpBody = postableAPI.body
+        }
+    }
+}

--- a/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodSurveyViewController.swift
+++ b/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodSurveyViewController.swift
@@ -52,11 +52,11 @@ final class DislikedFoodSurveyViewController: UIViewController, OnboardingConten
     private var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
     private var dataSource: DiffableDataSource!
     private var snapshot: NSDiffableDataSourceSnapshot<SectionKind, DislikedFoodCell.DislikedFood>!
-    private typealias CellRegistration = UICollectionView.CellRegistration<DislikedFoodCell, DislikedFoodCell.DislikedFood>
-    private typealias DiffableDataSource = UICollectionViewDiffableDataSource<SectionKind, DislikedFoodCell.DislikedFood>
-    
     private let invokedViewDidLoad = PublishSubject<Void>()
     private let disposeBag = DisposeBag()
+    
+    private typealias CellRegistration = UICollectionView.CellRegistration<DislikedFoodCell, DislikedFoodCell.DislikedFood>
+    private typealias DiffableDataSource = UICollectionViewDiffableDataSource<SectionKind, DislikedFoodCell.DislikedFood>
     
     // MARK: - Initializers
     convenience init(viewModel: DislikedFoodSurveyViewModel) {

--- a/WhatWeEat/Presentation/FlowCoordinator.swift
+++ b/WhatWeEat/Presentation/FlowCoordinator.swift
@@ -1,6 +1,7 @@
+import RxSwift
 import UIKit
 
-class FlowCoordinator {
+final class FlowCoordinator {
     // MARK: - Properties
     weak private var navigationController: UINavigationController?
     private var onboardingPageViewController: OnboardingPageViewController!
@@ -26,7 +27,7 @@ class FlowCoordinator {
         }
     }
     
-    func showOnboardingPage() {
+    private func showOnboardingPage() {
         let firstPage = OnboardingContentViewController(
             titleLabelText: Content.firstPageTitleLabelText,
             descriptionLabelText: Content.firstPageDescriptionLabelText,
@@ -51,8 +52,9 @@ class FlowCoordinator {
         navigationController?.pushViewController(onboardingPageViewController, animated: true)
     }
 
-    func showMainTabBarPage() {
-        let homeViewController = HomeViewController()
+    private func showMainTabBarPage() {
+        let homeViewModel = HomeViewModel()
+        let homeViewController = HomeViewController(viewModel: homeViewModel)
         let actions = TogetherMenuViewModelAction(showSharePinNumberPage: showSharePinNumberPage)
         let togetherMenuViewModel = TogetherMenuViewModel(actions: actions)
         let togetherMenuViewController = TogetherMenuViewController(viewModel: togetherMenuViewModel)
@@ -65,8 +67,8 @@ class FlowCoordinator {
         navigationController?.pushViewController(mainTabBarController, animated: true)
     }
     
-    func showSharePinNumberPage() {
-        let sharePinNumberPageViewModel = SharePinNumberPageViewModel()
+    private func showSharePinNumberPage(with pinNumber: Observable<Data>) {
+        let sharePinNumberPageViewModel = SharePinNumberPageViewModel(pinNumberData: pinNumber)
         let sharePinNumberPageViewController = SharePinNumberPageViewController(viewModel: sharePinNumberPageViewModel)
         
         navigationController?.pushViewController(sharePinNumberPageViewController, animated: false)

--- a/WhatWeEat/Presentation/MainTabBar/Home/ViewModel/HomeViewModel.swift
+++ b/WhatWeEat/Presentation/MainTabBar/Home/ViewModel/HomeViewModel.swift
@@ -1,0 +1,33 @@
+import UIKit
+import RxSwift
+
+final class HomeViewModel {
+    // MARK: - Nested Types
+    struct Input {
+        let invokedViewDidLoad: Observable<Void>
+    }
+    
+    struct Output {
+        let randomMenu: Observable<Menu>
+    }
+    
+    // MARK: - Properties
+    private let invokedViewDidLoad = PublishSubject<Void>()
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Methods
+    func transform(_ input: Input) -> Output {
+        let randomMenu = configureItems(by: input.invokedViewDidLoad)
+        
+        let output = Output(randomMenu: randomMenu)
+        
+        return output
+    }
+    
+    private func configureItems(by inputObserver: Observable<Void>) -> Observable<Menu> {
+        inputObserver.flatMap { () -> Observable<Menu> in
+            let randomMenuObservable = NetworkProvider().fetchData(api: RandomMenuAPI(), decodingType: Menu.self) 
+            return randomMenuObservable
+        }
+    }
+}

--- a/WhatWeEat/Presentation/MainTabBar/SoloMenu/View/SoloMenuViewController.swift
+++ b/WhatWeEat/Presentation/MainTabBar/SoloMenu/View/SoloMenuViewController.swift
@@ -36,7 +36,7 @@ final class SoloMenuViewController: UIViewController, TabBarContentProtocol {
         label.setContentHuggingPriority(.required, for: .vertical)
         return label
     }()
-    private let gameStartButton: UIButton = {
+    private let gameStartButton: UIButton = {  // TODO: ViewModel 추가하고 화면전환 구현
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle("미니게임 시작", for: .normal)

--- a/WhatWeEat/Presentation/MainTabBar/togetherMenu/View/SharePinNumberActivityItemSource.swift
+++ b/WhatWeEat/Presentation/MainTabBar/togetherMenu/View/SharePinNumberActivityItemSource.swift
@@ -31,7 +31,7 @@ final class SharePinNumberActivityItemSource: NSObject, UIActivityItemSource {
     
     func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
         let metaData = LPLinkMetadata()
-        guard let iconImage = UIImage(named: "meat") else {
+        guard let iconImage = UIImage(named: "meat") else {  // TODO: 디자인 작업 후 앱 로고로 변경
             return LPLinkMetadata()
         }
         metaData.title = title

--- a/WhatWeEat/Presentation/MainTabBar/togetherMenu/View/SharePinNumberPageViewController.swift
+++ b/WhatWeEat/Presentation/MainTabBar/togetherMenu/View/SharePinNumberPageViewController.swift
@@ -50,9 +50,6 @@ final class SharePinNumberPageViewController: UIViewController {
         label.textAlignment = .center
         label.font = .preferredFont(forTextStyle: .title1)
         label.backgroundColor = .systemGray4
-        label.text = """
-        PIN Number : 111
-        """
         label.numberOfLines = 0
         label.lineBreakStrategy = .hangulWordPriority
         return label
@@ -159,8 +156,18 @@ extension SharePinNumberPageViewController {
         
         let output = viewModel.transform(input)
         
+        configurePINNumber(with: output.pinNumber)
         configureBackButtonDidTap(with: output.backButtonDidTap)
         configureShareButtonDidTap(with: output.shareButtonDidTap)
+    }
+    
+    private func configurePINNumber(with pinNumber: Observable<String>) {
+        pinNumber
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] pinNumberText in
+                self?.pinNumberLabel.text = "PIN 번호 : \(pinNumberText)"
+            })
+            .disposed(by: disposeBag)
     }
     
     private func configureBackButtonDidTap(with backButtonDidTap: Observable<Void>) {
@@ -176,9 +183,11 @@ extension SharePinNumberPageViewController {
         shareButtonDidTap
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
+                guard let pinNumber = self?.pinNumberLabel.text else { return }
+                
                 let title = "[우리뭐먹지] 팀원과 PIN 번호를 공유해보세요"
                 let content = """
-                [우리뭐먹지] 팀원이 공유한 PIN 번호: 1111
+                [우리뭐먹지] 팀원이 공유한 \(pinNumber)
                 
                 PIN 번호를 통해 입장하여 오늘의 메뉴를 골라보세요
                 """

--- a/WhatWeEat/Presentation/MainTabBar/togetherMenu/ViewModel/SharePinNumberPageViewModel.swift
+++ b/WhatWeEat/Presentation/MainTabBar/togetherMenu/ViewModel/SharePinNumberPageViewModel.swift
@@ -9,15 +9,39 @@ final class SharePinNumberPageViewModel {
     }
 
     struct Output {
+        let pinNumber: Observable<String>
         let backButtonDidTap: Observable<Void>
         let shareButtonDidTap: Observable<Void>
     }
     
+    // MARK: - Properties
+    private let pinNumberData: Observable<Data>
+    
+    // MARK: - Initializers
+    init(pinNumberData: Observable<Data>) {
+        self.pinNumberData = pinNumberData
+    }
+    
     // MARK: - Methods
     func transform(_ input: Input) -> Output {
-        let output = Output(backButtonDidTap: input.backButtonDidTap,
-                            shareButtonDidTap: input.shareButtonDidTap)
+        let pinNumber = configurePINNumber()
+        
+        let output = Output(
+            pinNumber: pinNumber,
+            backButtonDidTap: input.backButtonDidTap,
+            shareButtonDidTap: input.shareButtonDidTap
+        )
         
         return output
+    }
+    
+    private func configurePINNumber() -> Observable<String> {
+        pinNumberData.map {
+            guard let pinNumberText = String(data: $0, encoding: .utf8) else {
+                return ""
+            }
+            
+            return pinNumberText
+        }
     }
 }

--- a/WhatWeEat/Presentation/MainTabBar/togetherMenu/ViewModel/TogetherMenuViewModel.swift
+++ b/WhatWeEat/Presentation/MainTabBar/togetherMenu/ViewModel/TogetherMenuViewModel.swift
@@ -25,7 +25,8 @@ final class TogetherMenuViewModel {
         inputObserver
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] _ in
-                self?.actions.showSharePinNumberPage()
+                let pinNumberObservable = NetworkProvider().request(api: CreateGroupAPI())
+                self?.actions.showSharePinNumberPage(pinNumberObservable)
             })
             .disposed(by: disposeBag)
     }

--- a/WhatWeEat/Presentation/MainTabBar/togetherMenu/ViewModel/TogetherMenuViewModelAction.swift
+++ b/WhatWeEat/Presentation/MainTabBar/togetherMenu/ViewModel/TogetherMenuViewModelAction.swift
@@ -1,5 +1,6 @@
 import Foundation
+import RxSwift
 
 struct TogetherMenuViewModelAction {
-    let showSharePinNumberPage: () -> Void
+    let showSharePinNumberPage: (Observable<Data>) -> Void
 }

--- a/WhatWeEat/Protocol/APIProtocol.swift
+++ b/WhatWeEat/Protocol/APIProtocol.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+protocol APIProtocol {
+    var url: URL? { get }
+    var method: HttpMethod { get }
+}
+
+protocol Gettable: APIProtocol { }
+
+protocol Postable: APIProtocol {
+    var identifier: String? { get }
+    var contentType: String? { get }
+    var body: Data? { get }
+}
+
+enum HttpMethod {
+    case get
+    case post
+    
+    var description: String {
+        switch self {
+        case .get:
+            return "GET"
+        case .post:
+            return "POST"
+        }
+    }
+}

--- a/WhatWeEat/Protocol/BaseURLProtocol.swift
+++ b/WhatWeEat/Protocol/BaseURLProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol BaseURLProtocol {
+    var baseURL: String { get }
+}

--- a/WhatWeEat/Protocol/URLSessionProtocol.swift
+++ b/WhatWeEat/Protocol/URLSessionProtocol.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol URLSessionProtocol {
+    func dataTask(with request: URLRequest,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+}
+
+extension URLSession: URLSessionProtocol { }

--- a/WhatWeEat/Protocol/URLSessionProtocol.swift
+++ b/WhatWeEat/Protocol/URLSessionProtocol.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-protocol URLSessionProtocol {
-    func dataTask(with request: URLRequest,
-                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
-}
-
-extension URLSession: URLSessionProtocol { }

--- a/WhatWeEat/Utility/JSONParser.swift
+++ b/WhatWeEat/Utility/JSONParser.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum JSONParserError: Error, LocalizedError {
+    case decodingFail
+    case encodingFail
+    
+    var errorDescription: String? {
+        switch self {
+        case .decodingFail:
+            return "디코딩에 실패했습니다."
+        case .encodingFail:
+            return "인코딩에 실패했습니다."
+        }
+    }
+}
+
+struct JSONParser<Item: Codable> {
+    func decode(from json: Data?) -> Item? {
+        guard let data = json else {
+            return nil
+        }
+        
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+//        decoder.dateDecodingStrategy = .formatted(DateFormatter.serverRequest)
+        
+        guard let decodedData = try? decoder.decode(Item.self, from: data) else { 
+            return nil
+        }
+        
+        return decodedData
+    }
+    
+    func encode(from item: Item?) -> Result<Data, JSONParserError> {
+        guard let item = item else {
+            return .failure(.encodingFail)
+        }
+        
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+//        encoder.dateEncodingStrategy = .formatted(DateFormatter.serverRequest)
+        
+        guard let encodedData = try? encoder.encode(item) else {
+            return .failure(.encodingFail)
+        }
+        
+        return .success(encodedData)
+    }
+}


### PR DESCRIPTION
# 배경
서버와 통신을 해서 홈탭의 랜덤 메뉴, 함께메뉴결정의 PIN 번호를 띄울 수 있도록 했습니다.

# 작업 내용
## 1. 네트워크 구현 및 API 추상화
`RxSwift`를 활용하여 비동기 작업을 처리했습니다. 서버에서 받아온 데이터는 `Observable` 타입으로 반환하고, ViewModel에서 ViewController에 전달하여 화면에 나타내는 구조로 구현했습니다.

API를 열거형으로 관리하는 경우, API를 추가할 때마다 새로운 case를 생성하여 열거형이 비대해지고, 열거형 관련 switch문을 매번 수정해야 하는 번거로움이 있었습니다. 따라서 API마다 독립적인 구조체 타입으로 관리되도록 변경하고, URL 프로퍼티 외에도 HttpMethod 프로퍼티를 추가한 APIProtocol 타입을 채택하도록 개선했습니다. 이로써 코드유지 보수가 용이하며, 협업 시 각자 담당한 API 구조체 타입만 관리하면 되기 때문에 충돌을 방지할 수 있습니다.

## 2. 데모 웹 애플리케이션을 통한 네트워크 테스트
`jar 실행파일`을 설치하여 `데모 웹 애플리케이션`을 통한 네트워크 테스트 (baseURL을 `http://localhost:8080/`로 설정)를 구현했습니다. 실제 서버와 독립적인 테스트를 실행한 이유는 아래와 같습니다.
- 실제 서버와 통신할 경우 테스트의 속도가 느려짐
- 인터넷 연결상태에 따라 테스트 결과가 달라지므로 테스트 신뢰도가 떨어짐
- 실제 서버와 통신을 하며 서버에 테스트 데이터가 불필요하게 업로드되는 Side-Effect가 발생함

## 3. 홈탭의 랜덤메뉴
랜덤메뉴의 이름, 이미지를 서버에서 받아 띄워줬습니다. 
`HomeViewController`의 `viewDidLoad` 시점에서 서버로부터 데이터를 받아오도록 했습니다. 이때 서버에서 보내주는 데이터 형식이 JSON이기 때문에, `Menu` Entity를 추가했습니다. 

추후 GameResult에 대한 데이터를 Get할 때에는 각 메뉴에 해당하는 키워드를 보여줘야 했기에 이는 옵셔널 타입으로 뒀습니다.

## 4. 함께메뉴결정 탭의 PIN 번호
`TogetherMenuViewController`의 `makeGroupButton`을 탭할 경우 `TogetherMenuViewModel`에서 서버에게 PIN 번호를 요청합니다.
`request(api:)` 메서드를 통해 `Observable<Int>`로 반환 값을 받으면 이를 FlowCoordinator의 `showSharePinNumberPage`로 전달 후 `SharePinNumberPageViewModel`로 전달하여 `SharePinNumberPageViewController`에서 View에 띄울 수 있도록 했습니다.
서버에서 JSON 형태로 데이터를 전달해주는 것이 아니라, Int 타입으로 PIN 번호만 보내주기 때문에 따로 Entity를 구현하진 않았습니다.

# 테스트 방법
데모 웹 애플리케이션을 로컬에 설치하여 서버 데이터가 정상적으로 반영되는지 확인합니다.

# 리뷰 노트
- 실제 Remote 서버 연결이 완료된 후 실기기 테스트를 통해 이미지가 너무 늦게 뜨는 경우 `Activity Indicator`를 추가할 예정입니다.

# 스크린샷
<img src="https://i.imgur.com/RPeN0ci.gif" width="250">