### PR TITLE
Main 화면의 NavigationBar 우상단의 설정 버튼을 탭하면 설정 화면이 나타납니다.

### DIFF
--- a/WhatWeEat.xcodeproj/project.pbxproj
+++ b/WhatWeEat.xcodeproj/project.pbxproj
@@ -49,6 +49,13 @@
 		DE51DC0A2844984C000FE0CB /* SharePinNumberActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51DC092844984C000FE0CB /* SharePinNumberActivityItemSource.swift */; };
 		DE69461B283C6ADC00BAA51D /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69461A283C6ADC00BAA51D /* OnboardingViewModel.swift */; };
 		DE69461D283CD1A700BAA51D /* DislikedFoodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69461C283CD1A700BAA51D /* DislikedFoodCell.swift */; };
+		DEEBE3912845C5DC002697B5 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3902845C5DC002697B5 /* SettingViewController.swift */; };
+		DEEBE3932845C6D3002697B5 /* SettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3922845C6D3002697B5 /* SettingCell.swift */; };
+		DEEBE3952845C6E6002697B5 /* VersionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3942845C6E6002697B5 /* VersionCell.swift */; };
+		DEEBE3982845C7CE002697B5 /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3972845C7CE002697B5 /* SettingViewModel.swift */; };
+		DEEBE39A28460A0B002697B5 /* UITableView+Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE39928460A0B002697B5 /* UITableView+Cell.swift */; };
+		DEEBE39E28461CEF002697B5 /* MainTabBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE39D28461CEF002697B5 /* MainTabBarViewModel.swift */; };
+		DEEBE3A028461DCF002697B5 /* MainTabBarViewModelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE39F28461DCF002697B5 /* MainTabBarViewModelAction.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +111,13 @@
 		DE51DC092844984C000FE0CB /* SharePinNumberActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePinNumberActivityItemSource.swift; sourceTree = "<group>"; };
 		DE69461A283C6ADC00BAA51D /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		DE69461C283CD1A700BAA51D /* DislikedFoodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DislikedFoodCell.swift; sourceTree = "<group>"; };
+		DEEBE3902845C5DC002697B5 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		DEEBE3922845C6D3002697B5 /* SettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCell.swift; sourceTree = "<group>"; };
+		DEEBE3942845C6E6002697B5 /* VersionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCell.swift; sourceTree = "<group>"; };
+		DEEBE3972845C7CE002697B5 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		DEEBE39928460A0B002697B5 /* UITableView+Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Cell.swift"; sourceTree = "<group>"; };
+		DEEBE39D28461CEF002697B5 /* MainTabBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModel.swift; sourceTree = "<group>"; };
+		DEEBE39F28461DCF002697B5 /* MainTabBarViewModelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModelAction.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -261,7 +275,8 @@
 		3636DEA6283E1A3800F04111 /* MainTabBar */ = {
 			isa = PBXGroup;
 			children = (
-				3636DEA9283E1B2C00F04111 /* MainTabBarController.swift */,
+				DEEBE39B28461CBF002697B5 /* View */,
+				DEEBE39C28461CC9002697B5 /* ViewModel */,
 				3636DEA8283E1AC800F04111 /* Home */,
 				3636DEBC283F75C800F04111 /* SoloMenu */,
 				DE31032B283F7FE3009CA7C3 /* togetherMenu */,
@@ -327,6 +342,7 @@
 			isa = PBXGroup;
 			children = (
 				3636DECE2844AD8300F04111 /* URLRequest+Initializer.swift */,
+				DEEBE39928460A0B002697B5 /* UITableView+Cell.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -362,8 +378,9 @@
 			children = (
 				3636DEAD283E302600F04111 /* FlowCoordinator.swift */,
 				3636DE87283B558300F04111 /* Onboarding */,
-				3636DE91283C86D900F04111 /* DislikedFoodSurvey */,
 				3636DEA6283E1A3800F04111 /* MainTabBar */,
+				DEEBE38E2845C5A6002697B5 /* Setting */,
+				3636DE91283C86D900F04111 /* DislikedFoodSurvey */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -419,6 +436,50 @@
 				DE310330283F84D4009CA7C3 /* TogetherMenuViewModel.swift */,
 				DE310332283F8673009CA7C3 /* TogetherMenuViewModelAction.swift */,
 				3636DEC228448A7200F04111 /* SharePinNumberPageViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		DEEBE38E2845C5A6002697B5 /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				DEEBE38F2845C5CD002697B5 /* View */,
+				DEEBE3962845C7B4002697B5 /* ViewModel */,
+			);
+			path = Setting;
+			sourceTree = "<group>";
+		};
+		DEEBE38F2845C5CD002697B5 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				DEEBE3902845C5DC002697B5 /* SettingViewController.swift */,
+				DEEBE3922845C6D3002697B5 /* SettingCell.swift */,
+				DEEBE3942845C6E6002697B5 /* VersionCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		DEEBE3962845C7B4002697B5 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				DEEBE3972845C7CE002697B5 /* SettingViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		DEEBE39B28461CBF002697B5 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				3636DEA9283E1B2C00F04111 /* MainTabBarController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		DEEBE39C28461CC9002697B5 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				DEEBE39D28461CEF002697B5 /* MainTabBarViewModel.swift */,
+				DEEBE39F28461DCF002697B5 /* MainTabBarViewModelAction.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -560,8 +621,10 @@
 				3636DE8D283B561A00F04111 /* OnboardingContentViewController.swift in Sources */,
 				DE31032A283F6446009CA7C3 /* FirstLaunchChecker.swift in Sources */,
 				DE31032D283F802E009CA7C3 /* TogetherMenuViewController.swift in Sources */,
+				DEEBE39E28461CEF002697B5 /* MainTabBarViewModel.swift in Sources */,
 				3636DEB5283F1D5F00F04111 /* TabBarContentProtocol.swift in Sources */,
 				3636DEB3283F1B3500F04111 /* DislikedFoodSurveyViewModelAction.swift in Sources */,
+				DEEBE3932845C6D3002697B5 /* SettingCell.swift in Sources */,
 				3636DEBF283F75F900F04111 /* SoloMenuViewController.swift in Sources */,
 				DE69461B283C6ADC00BAA51D /* OnboardingViewModel.swift in Sources */,
 				3636DEAE283E302600F04111 /* FlowCoordinator.swift in Sources */,
@@ -569,6 +632,7 @@
 				3636DEA2283E00FE00F04111 /* RealmManager.swift in Sources */,
 				3636DE8B283B55D300F04111 /* OnboardingPageViewController.swift in Sources */,
 				DE310331283F84D4009CA7C3 /* TogetherMenuViewModel.swift in Sources */,
+				DEEBE3982845C7CE002697B5 /* SettingViewModel.swift in Sources */,
 				3636DECA2844AD3900F04111 /* BaseURLProtocol.swift in Sources */,
 				DE310333283F8673009CA7C3 /* TogetherMenuViewModelAction.swift in Sources */,
 				3636DED42844AE3600F04111 /* WhatWeEatURL.swift in Sources */,
@@ -577,13 +641,17 @@
 				3636DEAC283E1B9900F04111 /* HomeViewController.swift in Sources */,
 				DE69461D283CD1A700BAA51D /* DislikedFoodCell.swift in Sources */,
 				3636DE55283B225100F04111 /* AppDelegate.swift in Sources */,
+				DEEBE3912845C5DC002697B5 /* SettingViewController.swift in Sources */,
 				3636DEAA283E1B2C00F04111 /* MainTabBarController.swift in Sources */,
 				3636DECF2844AD8300F04111 /* URLRequest+Initializer.swift in Sources */,
 				3636DEB1283E324F00F04111 /* OnboardingContentProtocol.swift in Sources */,
+				DEEBE3A028461DCF002697B5 /* MainTabBarViewModelAction.swift in Sources */,
 				3636DE94283C870800F04111 /* DislikedFoodSurveyViewController.swift in Sources */,
 				3636DE96283CCFD000F04111 /* AlertFactory.swift in Sources */,
 				3636DE99283CF98800F04111 /* DislikedFoodSurveyViewModel.swift in Sources */,
 				3636DED82844B06C00F04111 /* GameResult.swift in Sources */,
+				DEEBE3952845C6E6002697B5 /* VersionCell.swift in Sources */,
+				DEEBE39A28460A0B002697B5 /* UITableView+Cell.swift in Sources */,
 				DE51DC0A2844984C000FE0CB /* SharePinNumberActivityItemSource.swift in Sources */,
 				3636DED62844B00000F04111 /* Menu.swift in Sources */,
 				3636DE57283B225100F04111 /* SceneDelegate.swift in Sources */,

--- a/WhatWeEat.xcodeproj/project.pbxproj
+++ b/WhatWeEat.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		DE51DC0A2844984C000FE0CB /* SharePinNumberActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE51DC092844984C000FE0CB /* SharePinNumberActivityItemSource.swift */; };
 		DE69461B283C6ADC00BAA51D /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69461A283C6ADC00BAA51D /* OnboardingViewModel.swift */; };
 		DE69461D283CD1A700BAA51D /* DislikedFoodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69461C283CD1A700BAA51D /* DislikedFoodCell.swift */; };
+		DE86105628475881002D781B /* SettingDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86105528475881002D781B /* SettingDetailViewController.swift */; };
+		DE8610582847625E002D781B /* SettingDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8610572847625E002D781B /* SettingDetailViewModel.swift */; };
+		DE86105A28476288002D781B /* SettingDetailViewModelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86105928476288002D781B /* SettingDetailViewModelAction.swift */; };
 		DEEBE3912845C5DC002697B5 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3902845C5DC002697B5 /* SettingViewController.swift */; };
 		DEEBE3932845C6D3002697B5 /* SettingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3922845C6D3002697B5 /* SettingCell.swift */; };
 		DEEBE3952845C6E6002697B5 /* VersionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEBE3942845C6E6002697B5 /* VersionCell.swift */; };
@@ -113,6 +116,9 @@
 		DE51DC092844984C000FE0CB /* SharePinNumberActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePinNumberActivityItemSource.swift; sourceTree = "<group>"; };
 		DE69461A283C6ADC00BAA51D /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		DE69461C283CD1A700BAA51D /* DislikedFoodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DislikedFoodCell.swift; sourceTree = "<group>"; };
+		DE86105528475881002D781B /* SettingDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDetailViewController.swift; sourceTree = "<group>"; };
+		DE8610572847625E002D781B /* SettingDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDetailViewModel.swift; sourceTree = "<group>"; };
+		DE86105928476288002D781B /* SettingDetailViewModelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingDetailViewModelAction.swift; sourceTree = "<group>"; };
 		DEEBE3902845C5DC002697B5 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		DEEBE3922845C6D3002697B5 /* SettingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCell.swift; sourceTree = "<group>"; };
 		DEEBE3942845C6E6002697B5 /* VersionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCell.swift; sourceTree = "<group>"; };
@@ -457,6 +463,7 @@
 				DEEBE3902845C5DC002697B5 /* SettingViewController.swift */,
 				DEEBE3922845C6D3002697B5 /* SettingCell.swift */,
 				DEEBE3942845C6E6002697B5 /* VersionCell.swift */,
+				DE86105528475881002D781B /* SettingDetailViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -466,6 +473,8 @@
 			children = (
 				DEEBE3972845C7CE002697B5 /* SettingViewModel.swift */,
 				3636DEDC284718BB00F04111 /* SettingViewModelAction.swift */,
+				DE8610572847625E002D781B /* SettingDetailViewModel.swift */,
+				DE86105928476288002D781B /* SettingDetailViewModelAction.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -634,6 +643,7 @@
 				3636DEA5283E068B00F04111 /* DislikedFoodForRealm.swift in Sources */,
 				3636DEA2283E00FE00F04111 /* RealmManager.swift in Sources */,
 				3636DE8B283B55D300F04111 /* OnboardingPageViewController.swift in Sources */,
+				DE86105A28476288002D781B /* SettingDetailViewModelAction.swift in Sources */,
 				DE310331283F84D4009CA7C3 /* TogetherMenuViewModel.swift in Sources */,
 				DEEBE3982845C7CE002697B5 /* SettingViewModel.swift in Sources */,
 				3636DECA2844AD3900F04111 /* BaseURLProtocol.swift in Sources */,
@@ -655,9 +665,11 @@
 				3636DE99283CF98800F04111 /* DislikedFoodSurveyViewModel.swift in Sources */,
 				3636DED82844B06C00F04111 /* GameResult.swift in Sources */,
 				DEEBE3952845C6E6002697B5 /* VersionCell.swift in Sources */,
+				DE8610582847625E002D781B /* SettingDetailViewModel.swift in Sources */,
 				DEEBE39A28460A0B002697B5 /* UITableView+Cell.swift in Sources */,
 				DE51DC0A2844984C000FE0CB /* SharePinNumberActivityItemSource.swift in Sources */,
 				3636DED62844B00000F04111 /* Menu.swift in Sources */,
+				DE86105628475881002D781B /* SettingDetailViewController.swift in Sources */,
 				3636DE57283B225100F04111 /* SceneDelegate.swift in Sources */,
 				3636DECC2844AD4B00F04111 /* APIProtocol.swift in Sources */,
 				3636DE90283B5D6800F04111 /* ColorPalette.swift in Sources */,

--- a/WhatWeEat.xcodeproj/project.pbxproj
+++ b/WhatWeEat.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		3636DED62844B00000F04111 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DED52844B00000F04111 /* Menu.swift */; };
 		3636DED82844B06C00F04111 /* GameResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DED72844B06C00F04111 /* GameResult.swift */; };
 		3636DEDB2844CA7D00F04111 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEDA2844CA7D00F04111 /* HomeViewModel.swift */; };
+		3636DEDD284718BB00F04111 /* SettingViewModelAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3636DEDC284718BB00F04111 /* SettingViewModelAction.swift */; };
 		DE095C85283B241A00C7E109 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DE095C84283B241A00C7E109 /* RxCocoa */; };
 		DE095C87283B241A00C7E109 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DE095C86283B241A00C7E109 /* RxSwift */; };
 		DE31032A283F6446009CA7C3 /* FirstLaunchChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE310329283F6446009CA7C3 /* FirstLaunchChecker.swift */; };
@@ -104,6 +105,7 @@
 		3636DED52844B00000F04111 /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
 		3636DED72844B06C00F04111 /* GameResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameResult.swift; sourceTree = "<group>"; };
 		3636DEDA2844CA7D00F04111 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		3636DEDC284718BB00F04111 /* SettingViewModelAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModelAction.swift; sourceTree = "<group>"; };
 		DE310329283F6446009CA7C3 /* FirstLaunchChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstLaunchChecker.swift; sourceTree = "<group>"; };
 		DE31032C283F802E009CA7C3 /* TogetherMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogetherMenuViewController.swift; sourceTree = "<group>"; };
 		DE310330283F84D4009CA7C3 /* TogetherMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TogetherMenuViewModel.swift; sourceTree = "<group>"; };
@@ -463,6 +465,7 @@
 			isa = PBXGroup;
 			children = (
 				DEEBE3972845C7CE002697B5 /* SettingViewModel.swift */,
+				3636DEDC284718BB00F04111 /* SettingViewModelAction.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 				3636DECA2844AD3900F04111 /* BaseURLProtocol.swift in Sources */,
 				DE310333283F8673009CA7C3 /* TogetherMenuViewModelAction.swift in Sources */,
 				3636DED42844AE3600F04111 /* WhatWeEatURL.swift in Sources */,
+				3636DEDD284718BB00F04111 /* SettingViewModelAction.swift in Sources */,
 				3636DEDB2844CA7D00F04111 /* HomeViewModel.swift in Sources */,
 				3636DED12844ADFD00F04111 /* JSONParser.swift in Sources */,
 				3636DEAC283E1B9900F04111 /* HomeViewController.swift in Sources */,
@@ -811,7 +815,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = FA464JRW3F;
+				DEVELOPMENT_TEAM = XD7KFVM4LP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WhatWeEat/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -823,7 +827,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.applecider.WhatWeEat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WhatWeEat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -838,7 +842,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = FA464JRW3F;
+				DEVELOPMENT_TEAM = XD7KFVM4LP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WhatWeEat/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -850,7 +854,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.applecider.WhatWeEat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.WhatWeEat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/WhatWeEat/Data/LocalDB/Realm/Entity/DislikedFoodForRealm.swift
+++ b/WhatWeEat/Data/LocalDB/Realm/Entity/DislikedFoodForRealm.swift
@@ -1,7 +1,6 @@
 import Foundation
 import RealmSwift
 
-// TODO: Remote 서버에 못먹는음식 데이터 보낼 때, Model 타입 확인
 class DislikedFoodForRealM: Object {
     @Persisted var name: String
     

--- a/WhatWeEat/Data/LocalDB/Realm/RealmManager.swift
+++ b/WhatWeEat/Data/LocalDB/Realm/RealmManager.swift
@@ -6,4 +6,25 @@ struct RealmManager {
     let realm = try! Realm()
     
     private init() { }
+    
+    func deleteAndCreate(_ checkedFoods: [DislikedFoodCell.DislikedFood]) {
+        try! realm.write {
+            realm.deleteAll()
+            
+            checkedFoods.forEach {
+                let dislikedFood = DislikedFoodForRealM(name: $0.name)
+                realm.add(dislikedFood)
+            }
+        }
+    }
+
+    func read() -> [String] {
+        var checkedDislikedFoods = [String]()
+        let checkedFoodsFromRealm = realm.objects(DislikedFoodForRealM.self)
+        checkedFoodsFromRealm.forEach {
+            checkedDislikedFoods.append($0.name)
+        }
+        
+        return checkedDislikedFoods
+    }
 }

--- a/WhatWeEat/Data/LocalDB/UserDefaults/FirstLaunchChecker.swift
+++ b/WhatWeEat/Data/LocalDB/UserDefaults/FirstLaunchChecker.swift
@@ -4,7 +4,6 @@ struct FirstLaunchChecker {
     static func isFirstLaunched() -> Bool {
         let userDefaults = UserDefaults.standard
         if userDefaults.object(forKey: "isFirstLaunched") == nil {
-            UserDefaults.standard.set(false, forKey: "isFirstLaunched")
             return true
         } else {
             return false

--- a/WhatWeEat/Data/RemoteDB/NetworkProvider.swift
+++ b/WhatWeEat/Data/RemoteDB/NetworkProvider.swift
@@ -19,10 +19,10 @@ enum NetworkError: Error, LocalizedError {
 }
 
 struct NetworkProvider {
-    private let session: URLSessionProtocol
+    private let session: URLSession
     private let disposeBag = DisposeBag()
     
-    init(session: URLSessionProtocol = URLSession.shared) {
+    init(session: URLSession = URLSession.shared) {
         self.session = session
     }
     

--- a/WhatWeEat/Extension/UITableView+Cell.swift
+++ b/WhatWeEat/Extension/UITableView+Cell.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+extension UITableView {
+    func register<T: UITableViewCell>(cellType: T.Type) {
+        register(cellType, forCellReuseIdentifier: String(describing: cellType))
+    }
+    
+    func dequeueReusableCell<T: UITableViewCell>(of cellType: T.Type, for indexPath: IndexPath) -> T {
+        guard let cell = dequeueReusableCell(withIdentifier: String(describing: cellType), for: indexPath) as? T else {
+            return T()
+        }
+        return cell
+    }
+}

--- a/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodCell.swift
+++ b/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodCell.swift
@@ -3,11 +3,29 @@ import RealmSwift
 
 final class DislikedFoodCell: UICollectionViewCell {
     // MARK: - Nested Types
-    struct DislikedFood: Hashable {
+    class DislikedFood: Hashable {
         var isChecked: Bool = false
         let name: String
         let descriptionImage: UIImage
         let descriptionText: String
+        
+        init(name: String, descriptionImage: UIImage, descriptionText: String) {
+            self.name = name
+            self.descriptionImage = descriptionImage
+            self.descriptionText = descriptionText
+        }
+        
+        func toggleChecked() {
+            self.isChecked.toggle()
+        }
+        
+        static func == (lhs: DislikedFoodCell.DislikedFood, rhs: DislikedFoodCell.DislikedFood) -> Bool {
+            return lhs.name == rhs.name
+        }
+        
+        func hash(into hasher: inout Hasher) {
+           hasher.combine(name)
+        }
     }
     
     // MARK: - Properties
@@ -62,7 +80,10 @@ final class DislikedFoodCell: UICollectionViewCell {
     }
     
     // MARK: - Methods
-    func apply(descriptionImage: UIImage, descriptionText: String) {
+    func apply(isChecked: Bool, descriptionImage: UIImage, descriptionText: String) {
+        if isChecked {
+            toggleSelectedCellUI()
+        }
         descriptionImageView.image = descriptionImage
         descriptionLabel.text = descriptionText
     }

--- a/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodSurveyViewController.swift
+++ b/WhatWeEat/Presentation/DislikedFoodSurvey/View/DislikedFoodSurveyViewController.swift
@@ -68,6 +68,7 @@ final class DislikedFoodSurveyViewController: UIViewController, OnboardingConten
     override func viewDidLoad() {
         super.viewDidLoad()
         checkIOSVersion()
+        configureNavigationBar()
         configureCollectionView()
         configureStackView()
         configureCellRegistrationAndDataSource()
@@ -94,6 +95,10 @@ final class DislikedFoodSurveyViewController: UIViewController, OnboardingConten
         let okAlertAction = UIAlertAction(title: Content.okAlertActionTitle, style: .default)
         let alert = AlertFactory().createAlert(title: Content.versionErrorTitle, message: nil, actions: okAlertAction)
         present(alert, animated: true)
+    }
+    
+    private func configureNavigationBar() {
+        navigationItem.hidesBackButton = true
     }
     
     private func configureCollectionView() {
@@ -123,7 +128,7 @@ final class DislikedFoodSurveyViewController: UIViewController, OnboardingConten
     
     private func configureCellRegistrationAndDataSource() {
         let cellRegistration = CellRegistration { cell, _, dislikedFood in
-            cell.apply(descriptionImage: dislikedFood.descriptionImage, descriptionText: dislikedFood.descriptionText)
+            cell.apply(isChecked: dislikedFood.isChecked, descriptionImage: dislikedFood.descriptionImage, descriptionText: dislikedFood.descriptionText)
         }
         
         dataSource = DiffableDataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, dislikedFood in

--- a/WhatWeEat/Presentation/DislikedFoodSurvey/ViewModel/DislikedFoodSurveyViewModelAction.swift
+++ b/WhatWeEat/Presentation/DislikedFoodSurvey/ViewModel/DislikedFoodSurveyViewModelAction.swift
@@ -2,4 +2,5 @@ import Foundation
 
 struct DislikedFoodSurveyViewModelAction {
     let showMainTapBarPage: () -> Void
+    let popCurrentPage: (() -> Void)?
 }

--- a/WhatWeEat/Presentation/FlowCoordinator.swift
+++ b/WhatWeEat/Presentation/FlowCoordinator.swift
@@ -55,13 +55,16 @@ final class FlowCoordinator {
     private func showMainTabBarPage() {
         let homeViewModel = HomeViewModel()
         let homeViewController = HomeViewController(viewModel: homeViewModel)
-        let actions = TogetherMenuViewModelAction(showSharePinNumberPage: showSharePinNumberPage)
-        let togetherMenuViewModel = TogetherMenuViewModel(actions: actions)
+        let togetherMenuViewModelactions = TogetherMenuViewModelAction(showSharePinNumberPage: showSharePinNumberPage)
+        let togetherMenuViewModel = TogetherMenuViewModel(actions: togetherMenuViewModelactions)
         let togetherMenuViewController = TogetherMenuViewController(viewModel: togetherMenuViewModel)
         let soloMenuViewController = SoloMenuViewController()
-
+        
+        let mainTabBarViewModelAction = MainTabBarViewModelAction(showSettingPage: showSettingPage)
+        let mainTabBarViewModel = MainTabBarViewModel(actions: mainTabBarViewModelAction)
         let mainTabBarController = MainTabBarController(
-            pages: [homeViewController, togetherMenuViewController, soloMenuViewController]
+            pages: [homeViewController, togetherMenuViewController, soloMenuViewController],
+            viewModel: mainTabBarViewModel
         )
         
         navigationController?.pushViewController(mainTabBarController, animated: true)
@@ -72,6 +75,13 @@ final class FlowCoordinator {
         let sharePinNumberPageViewController = SharePinNumberPageViewController(viewModel: sharePinNumberPageViewModel)
         
         navigationController?.pushViewController(sharePinNumberPageViewController, animated: false)
+    }
+    
+    private func showSettingPage() {
+        let settingViewModel = SettingViewModel()
+        let settingViewController = SettingViewController(viewModel: settingViewModel)
+        
+        navigationController?.pushViewController(settingViewController, animated: true)
     }
 }
 

--- a/WhatWeEat/Presentation/FlowCoordinator.swift
+++ b/WhatWeEat/Presentation/FlowCoordinator.swift
@@ -39,7 +39,7 @@ final class FlowCoordinator {
             image: Content.secondPageImage
         )
         
-        let actions = DislikedFoodSurveyViewModelAction(showMainTapBarPage: showMainTabBarPage)
+        let actions = DislikedFoodSurveyViewModelAction(showMainTapBarPage: showMainTabBarPage, popCurrentPage: nil)
         let dislikedFoodSurveyViewModel = DislikedFoodSurveyViewModel(actions: actions)
         let thirdPage = DislikedFoodSurveyViewController(viewModel: dislikedFoodSurveyViewModel)
         
@@ -78,10 +78,27 @@ final class FlowCoordinator {
     }
     
     private func showSettingPage() {
-        let settingViewModel = SettingViewModel()
+        let settingViewModelAction = SettingViewModelAction(showDislikedFoodSurveyPage: showDislikedFoodSurveyPage) // 여러개 전달
+        let settingViewModel = SettingViewModel(actions: settingViewModelAction)
         let settingViewController = SettingViewController(viewModel: settingViewModel)
         
         navigationController?.pushViewController(settingViewController, animated: true)
+    }
+    
+    private func showDislikedFoodSurveyPage() {
+        let actions = DislikedFoodSurveyViewModelAction(showMainTapBarPage: showMainTabBarPage, popCurrentPage: popCurrentPage)
+        let dislikedFoodSurveyViewModel = DislikedFoodSurveyViewModel(actions: actions) // 다시 설정으로 돌아오도록
+        let dislikedFoodSurveyViewController = DislikedFoodSurveyViewController(viewModel: dislikedFoodSurveyViewModel)
+        
+        navigationController?.pushViewController(dislikedFoodSurveyViewController, animated: false)
+    }
+    
+    private func popCurrentPage() {
+        navigationController?.popViewController(animated: false)
+    }
+    
+    private func showAppStorePage() {
+        // TODO: 링크를 통해 APPStore 앱 연결
     }
 }
 

--- a/WhatWeEat/Presentation/FlowCoordinator.swift
+++ b/WhatWeEat/Presentation/FlowCoordinator.swift
@@ -78,7 +78,10 @@ final class FlowCoordinator {
     }
     
     private func showSettingPage() {
-        let settingViewModelAction = SettingViewModelAction(showDislikedFoodSurveyPage: showDislikedFoodSurveyPage) // 여러개 전달
+        let settingViewModelAction = SettingViewModelAction(
+            showDislikedFoodSurveyPage: showDislikedFoodSurveyPage,
+            showSettingDetailPage: showSettingDetailPageWith
+        )
         let settingViewModel = SettingViewModel(actions: settingViewModelAction)
         let settingViewController = SettingViewController(viewModel: settingViewModel)
         
@@ -95,6 +98,18 @@ final class FlowCoordinator {
     
     private func popCurrentPage() {
         navigationController?.popViewController(animated: false)
+    }
+    
+    private func showSettingDetailPageWith(title: String, content: String) {
+        let actions = SettingDetailViewModelAction(popCurrentPage: popCurrentPage)
+        let settingDetailViewModel = SettingDetailViewModel(actions: actions)
+        let settingDetailViewController = SettingDetailViewController(
+            title: title,
+            content: content,
+            viewModel: settingDetailViewModel
+        )
+        
+        navigationController?.pushViewController(settingDetailViewController, animated: false)
     }
     
     private func showAppStorePage() {

--- a/WhatWeEat/Presentation/MainTabBar/View/MainTabBarController.swift
+++ b/WhatWeEat/Presentation/MainTabBar/View/MainTabBarController.swift
@@ -3,11 +3,13 @@ import UIKit
 final class MainTabBarController: UITabBarController {
     // MARK: - Properties
     private var pages: [TabBarContentProtocol]!
+    private var viewModel: MainTabBarViewModel!
     
     // MARK: - Initializers
-    init(pages: [TabBarContentProtocol]) {
+    init(pages: [TabBarContentProtocol], viewModel: MainTabBarViewModel) {
         super.init(nibName: nil, bundle: nil)
         self.pages = pages
+        self.viewModel = viewModel
     }
     
     @available(*, unavailable)
@@ -25,6 +27,7 @@ final class MainTabBarController: UITabBarController {
         // ???: UITabBarController init의 side-effect로 인해 viewDidLoad 대신 해당 위치에 배치함
         configureNavigationBar()
         configureTabBar()
+        bind()
     }
     
     // MARK: - Methods
@@ -63,5 +66,15 @@ extension MainTabBarController: UITabBarControllerDelegate {
         default:
             navigationItem.title = "우리뭐먹지"
         }
+    }
+}
+
+// MARK: - Rx Binding Methods
+extension MainTabBarController {
+    private func bind() {
+        guard let rightBarButtonItem = navigationItem.rightBarButtonItem else { return }
+        let input = MainTabBarViewModel.Input(rightBarButtonItemDidTap: rightBarButtonItem.rx.tap.asObservable())
+        
+        viewModel.transform(input)
     }
 }

--- a/WhatWeEat/Presentation/MainTabBar/ViewModel/MainTabBarViewModel.swift
+++ b/WhatWeEat/Presentation/MainTabBar/ViewModel/MainTabBarViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import RxSwift
+
+final class MainTabBarViewModel {
+    struct Input {
+        let rightBarButtonItemDidTap: Observable<Void>
+    }
+    
+    // MARK: - Properties
+    private let actions: MainTabBarViewModelAction!
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Initializers
+    init(actions: MainTabBarViewModelAction) {
+        self.actions = actions
+    }
+    
+    func transform(_ input: Input) {
+        configureRightBarButtonItemDidTap(with: input.rightBarButtonItemDidTap)
+    }
+    
+    private func configureRightBarButtonItemDidTap(with inputObserver: Observable<Void>) {
+        inputObserver
+            .subscribe(onNext: { [weak self] _ in
+                self?.actions.showSettingPage()
+            })
+            .disposed(by: disposeBag)
+    }
+}
+

--- a/WhatWeEat/Presentation/MainTabBar/ViewModel/MainTabBarViewModelAction.swift
+++ b/WhatWeEat/Presentation/MainTabBar/ViewModel/MainTabBarViewModelAction.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct MainTabBarViewModelAction {
+    let showSettingPage: () -> Void
+}

--- a/WhatWeEat/Presentation/MainTabBar/togetherMenu/View/SharePinNumberPageViewController.swift
+++ b/WhatWeEat/Presentation/MainTabBar/togetherMenu/View/SharePinNumberPageViewController.swift
@@ -174,7 +174,7 @@ extension SharePinNumberPageViewController {
         backButtonDidTap
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
-                self?.navigationController?.popViewController(animated: false)
+                self?.navigationController?.popViewController(animated: false) // TODO: ViewModel Action으로 연결 고려
             })
             .disposed(by: disposeBag)
     }

--- a/WhatWeEat/Presentation/Setting/View/SettingCell.swift
+++ b/WhatWeEat/Presentation/Setting/View/SettingCell.swift
@@ -1,0 +1,67 @@
+//
+//  SettingCell.swift
+//  WhatWeEat
+//
+//  Created by 양호준 on 2022/05/31.
+//
+
+import UIKit
+
+class SettingCell: UITableViewCell {
+    // MARK: - Properties
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .left
+        label.font = Design.titleLabelFont
+        label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
+        return label
+    }()
+    
+    // MARK: - Initializers
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - LifeCycle Methods
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+//        self.backgroundColor = ColorPalette.subYellow
+    }
+    
+    // MARK: - Methods
+    func apply(title: String) {
+        titleLabel.text = title
+    }
+    
+    private func configureUI() {
+        self.accessoryType = .disclosureIndicator
+        addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: 30),
+            titleLabel.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -60),
+            titleLabel.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 5),
+            titleLabel.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -5),
+        ])
+    }
+}
+
+// MARK: - NameSpace
+extension SettingCell {
+    private enum Design {
+        static let titleLabelFont: UIFont = .preferredFont(forTextStyle: .title3)
+    }
+}

--- a/WhatWeEat/Presentation/Setting/View/SettingCell.swift
+++ b/WhatWeEat/Presentation/Setting/View/SettingCell.swift
@@ -1,10 +1,3 @@
-//
-//  SettingCell.swift
-//  WhatWeEat
-//
-//  Created by 양호준 on 2022/05/31.
-//
-
 import UIKit
 
 class SettingCell: UITableViewCell {
@@ -30,15 +23,10 @@ class SettingCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - LifeCycle Methods
+    // MARK: - Lifecycle Methods
     override func prepareForReuse() {
         super.prepareForReuse()
         titleLabel.text = nil
-    }
-    
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-//        self.backgroundColor = ColorPalette.subYellow
     }
     
     // MARK: - Methods
@@ -48,18 +36,19 @@ class SettingCell: UITableViewCell {
     
     private func configureUI() {
         self.accessoryType = .disclosureIndicator
+        self.selectionStyle = .none
         addSubview(titleLabel)
         
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: 30),
             titleLabel.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -60),
-            titleLabel.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 5),
-            titleLabel.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -5),
+            titleLabel.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 10),
+            titleLabel.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -10),
         ])
     }
 }
 
-// MARK: - NameSpace
+// MARK: - NameSpaces
 extension SettingCell {
     private enum Design {
         static let titleLabelFont: UIFont = .preferredFont(forTextStyle: .title3)

--- a/WhatWeEat/Presentation/Setting/View/SettingDetailViewController.swift
+++ b/WhatWeEat/Presentation/Setting/View/SettingDetailViewController.swift
@@ -1,0 +1,71 @@
+import UIKit
+
+class SettingDetailViewController: UIViewController {
+    // MARK: - Properties
+    private let textView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.textContainer.lineBreakMode = .byWordWrapping
+        textView.dataDetectorTypes = .all
+        textView.textContainerInset = UIEdgeInsets(top: 30, left: 10, bottom: 10, right: 10)
+        textView.isEditable = false
+        return textView
+    }()
+    
+    private var settingTitle: String = ""
+    private var content: String = ""
+    private var viewModel: SettingDetailViewModel!
+    
+    // MARK: - Initializers
+    convenience init(title: String, content: String, viewModel: SettingDetailViewModel) {
+        self.init()
+        self.settingTitle = title
+        self.content = content
+        self.viewModel = viewModel
+    }
+    
+    // MARK: - Lifecycle Methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureUI()
+        bind()
+    }
+    
+    // MARK: - Methods
+    private func configureNavigationBar() {
+        let backButtonImage = UIImage(systemName: "arrow.backward")
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            image: backButtonImage,
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        navigationItem.leftBarButtonItem?.tintColor = .black
+        navigationItem.title = settingTitle
+    }
+    
+    private func configureUI() {
+        view.addSubview(textView)
+        view.backgroundColor = ColorPalette.mainYellow
+        textView.text = content
+        
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            textView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            textView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+        ])
+    }
+}
+
+// MARK: - Rx Binding Methods
+extension SettingDetailViewController {
+    private func bind() {
+        guard let leftBarButtonItem = navigationItem.leftBarButtonItem else { return }
+        let input = SettingDetailViewModel.Input(backButtonDidTap: leftBarButtonItem.rx.tap.asObservable())
+        
+        viewModel.transform(input)
+    }
+}

--- a/WhatWeEat/Presentation/Setting/View/SettingViewController.swift
+++ b/WhatWeEat/Presentation/Setting/View/SettingViewController.swift
@@ -6,12 +6,12 @@ final class SettingViewController: UIViewController {
     // MARK: - Nested Types
     enum SectionKind: Int, CaseIterable {
         case dislikedFood
-        case ordinarySetting
+        case ordinary 
         case version
     }
     
     // MARK: - Properties
-    private let tableView = UITableView()
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
     private var viewModel: SettingViewModel!
     private let invokedViewDidLoad = PublishSubject<Void>()
     private let disposeBag = DisposeBag()
@@ -50,9 +50,10 @@ final class SettingViewController: UIViewController {
         self.view.backgroundColor = ColorPalette.mainYellow
         self.view.addSubview(tableView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.backgroundColor = .white
+        tableView.backgroundColor = .systemGray6
         tableView.register(cellType: VersionCell.self)
         tableView.register(cellType: SettingCell.self)
+        tableView.dataSource = self
         
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
@@ -60,7 +61,6 @@ final class SettingViewController: UIViewController {
             tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             tableView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
         ])
-        tableView.dataSource = self
     }
 }
 
@@ -71,7 +71,8 @@ extension SettingViewController {
         
         let input = SettingViewModel.Input(
             invokedViewDidLoad: invokedViewDidLoad.asObservable(),
-            backButtonDidTap: leftNavigationItem.rx.tap.asObservable()
+            backButtonDidTap: leftNavigationItem.rx.tap.asObservable(),
+            settingItemDidSelect: tableView.rx.itemSelected.asObservable()
         )
         
         let output = viewModel.transform(input)
@@ -110,8 +111,8 @@ extension SettingViewController: UITableViewDataSource {
         case .dislikedFood:
             let dislikedFoodItems = settingItems.filter { $0.sectionKind == .dislikedFood }
             return dislikedFoodItems.count
-        case .ordinarySetting:
-            let ordinarySettingItems = settingItems.filter { $0.sectionKind == .ordinarySetting }
+        case .ordinary:
+            let ordinarySettingItems = settingItems.filter { $0.sectionKind == .ordinary }
             return ordinarySettingItems.count
         case .version:
             let versionItems = settingItems.filter { $0.sectionKind == .version }
@@ -132,9 +133,9 @@ extension SettingViewController: UITableViewDataSource {
             }
 
             return cell
-        case .ordinarySetting:
+        case .ordinary:
             let cell = tableView.dequeueReusableCell(of: SettingCell.self, for: indexPath)
-            guard let ordinarySettingItems = settingItems.filter({ $0.sectionKind == .ordinarySetting }) as? [SettingViewModel.OrdinarySettingItem] else {
+            guard let ordinarySettingItems = settingItems.filter({ $0.sectionKind == .ordinary }) as? [SettingViewModel.OrdinarySettingItem] else {
                 return UITableViewCell()
             }
             

--- a/WhatWeEat/Presentation/Setting/View/SettingViewController.swift
+++ b/WhatWeEat/Presentation/Setting/View/SettingViewController.swift
@@ -1,0 +1,155 @@
+import RxCocoa
+import RxSwift
+import UIKit
+
+final class SettingViewController: UIViewController {
+    // MARK: - Nested Types
+    enum SectionKind: Int, CaseIterable {
+        case dislikedFood
+        case ordinarySetting
+        case version
+    }
+    
+    // MARK: - Properties
+    private let tableView = UITableView()
+    private var viewModel: SettingViewModel!
+    private let invokedViewDidLoad = PublishSubject<Void>()
+    private let disposeBag = DisposeBag()
+    private var viewModelOutput: SettingViewModel.Output?
+    private var settingItems = [SettingItem]()
+    
+    // MARK: - Initializers
+    convenience init(viewModel: SettingViewModel) {
+        self.init()
+        self.viewModel = viewModel
+    }
+    
+    // MARK: - Lifecycle Methods
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureTableView()
+        bind()
+        invokedViewDidLoad.onNext(())
+    }
+    
+    // MARK: - Methods
+    private func configureNavigationBar() {
+        let backButtonImage = UIImage(systemName: "arrow.backward")
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            image: backButtonImage,
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        navigationItem.leftBarButtonItem?.tintColor = .black
+        navigationItem.title = "설정"
+    }
+    
+    private func configureTableView() {
+        self.view.backgroundColor = ColorPalette.mainYellow
+        self.view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = .white
+        tableView.register(cellType: VersionCell.self)
+        tableView.register(cellType: SettingCell.self)
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            tableView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+        ])
+        tableView.dataSource = self
+    }
+}
+
+// MARK: - Rx Binding Methods
+extension SettingViewController {
+    private func bind() {
+        guard let leftNavigationItem = navigationItem.leftBarButtonItem else { return }
+        
+        let input = SettingViewModel.Input(
+            invokedViewDidLoad: invokedViewDidLoad.asObservable(),
+            backButtonDidTap: leftNavigationItem.rx.tap.asObservable()
+        )
+        
+        let output = viewModel.transform(input)
+        
+        configureTableViewItems(with: output.tableViewItems)
+        configureBackButtonDidTap(with: output.backButtonDidTap)
+    }
+    
+    private func configureTableViewItems(with items: Observable<[SettingItem]>) {
+        items
+            .subscribe(onNext: { [weak self] items in
+                self?.settingItems = items as [SettingItem]
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func configureBackButtonDidTap(with backButtonDidTap: Observable<Void>) {
+        backButtonDidTap
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: false)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+// MARK: - TableView DataSource
+extension SettingViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return SectionKind.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let sectionKind = SectionKind(rawValue: section) else { return 0 }
+        switch sectionKind {
+        case .dislikedFood:
+            let dislikedFoodItems = settingItems.filter { $0.sectionKind == .dislikedFood }
+            return dislikedFoodItems.count
+        case .ordinarySetting:
+            let ordinarySettingItems = settingItems.filter { $0.sectionKind == .ordinarySetting }
+            return ordinarySettingItems.count
+        case .version:
+            let versionItems = settingItems.filter { $0.sectionKind == .version }
+            return versionItems.count
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let sectionKind = SectionKind(rawValue: indexPath.section) else { return UITableViewCell() }
+        switch sectionKind {
+        case .dislikedFood:
+            let cell = tableView.dequeueReusableCell(of: SettingCell.self, for: indexPath)
+            guard let dislikedFoodItems = settingItems.filter({ $0.sectionKind == .dislikedFood }) as? [SettingViewModel.OrdinarySettingItem] else {
+                return UITableViewCell()
+            }
+            dislikedFoodItems.forEach { dislikedFoodItem in
+                cell.apply(title: dislikedFoodItem.title)
+            }
+
+            return cell
+        case .ordinarySetting:
+            let cell = tableView.dequeueReusableCell(of: SettingCell.self, for: indexPath)
+            guard let ordinarySettingItems = settingItems.filter({ $0.sectionKind == .ordinarySetting }) as? [SettingViewModel.OrdinarySettingItem] else {
+                return UITableViewCell()
+            }
+            
+            cell.apply(title: ordinarySettingItems[indexPath.row].title)
+
+            return cell
+        case .version:
+            let cell = tableView.dequeueReusableCell(of: VersionCell.self, for: indexPath)
+            let versionItems = settingItems.filter { $0.sectionKind == .version }
+            guard let versionItem = versionItems.first as? SettingViewModel.VersionSettingItem else {
+                return UITableViewCell()
+            }
+            cell.apply(title: versionItem.title, subtitle: versionItem.subtitle, buttonTitle: versionItem.buttonTitle)
+
+            return cell
+        }
+    }
+}

--- a/WhatWeEat/Presentation/Setting/View/VersionCell.swift
+++ b/WhatWeEat/Presentation/Setting/View/VersionCell.swift
@@ -42,9 +42,9 @@ class VersionCell: UITableViewCell {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.layer.cornerRadius = 5
-        button.backgroundColor = Design.versionStatusButtonBackgroundColor
-        button.setTitleColor(Design.versionStatusButtonTitleColor, for: .normal)
         button.titleLabel?.font = Design.versionStatusButtonTitleFont
+        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 2, bottom: 0, right: 2)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
         return button
     }()
     
@@ -52,6 +52,7 @@ class VersionCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         configureUI()
+        self.isUserInteractionEnabled = false
     }
     
     @available(*, unavailable)
@@ -59,17 +60,13 @@ class VersionCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - LifeCycle Methods
+    // MARK: - Lifecycle Methods
     override func prepareForReuse() {
         super.prepareForReuse()
         titleLabel.text = nil
         subtitleLabel.text = nil
         versionStatusButton.setTitle(nil, for: .normal)
-    }
-    
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-//        self.backgroundColor = ColorPalette.subYellow
+        versionStatusButton.isUserInteractionEnabled = true
     }
     
     // MARK: - Methods
@@ -77,6 +74,18 @@ class VersionCell: UITableViewCell {
         titleLabel.text = title
         subtitleLabel.text = subtitle
         versionStatusButton.setTitle(buttonTitle, for: .normal)
+        setupVersionStatusButton()
+    }
+    
+    private func setupVersionStatusButton() {
+        if versionStatusButton.titleLabel?.text == Content.versionInformationButtonUpdateTitle {
+            versionStatusButton.setTitleColor(Design.versionStatusButtonUpdateTitleColor, for: .normal)
+            versionStatusButton.backgroundColor = ColorPalette.mainYellow
+        } else {
+            versionStatusButton.setTitleColor(Design.versionStatusButtonLatestTitleColor, for: .normal)
+            versionStatusButton.backgroundColor = Design.versionStatusButtonLatestBackgroundColor
+            versionStatusButton.isUserInteractionEnabled = false
+        }
     }
     
     private func configureUI() {
@@ -87,15 +96,17 @@ class VersionCell: UITableViewCell {
         titleStackView.addArrangedSubview(subtitleLabel)
         
         NSLayoutConstraint.activate([
-            containerStackView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 5),
+            containerStackView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 8),
             containerStackView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: 30),
             containerStackView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-            containerStackView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -5),
+            containerStackView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -8),
+            
+            versionStatusButton.widthAnchor.constraint(equalTo: self.safeAreaLayoutGuide.widthAnchor, multiplier: 0.2)
         ])
     }
 }
 
-// MARK: - NameSpace
+// MARK: - NameSpaces
 extension VersionCell {
     private enum Design {
         static let titleLabelFont: UIFont = .preferredFont(forTextStyle: .title3)
@@ -103,8 +114,15 @@ extension VersionCell {
         static let subtitleLabelFont: UIFont = .preferredFont(forTextStyle: .body)
         static let subtilteLabelTextColor: UIColor = .systemGray
         
-        static let versionStatusButtonTitleColor: UIColor = .black
         static let versionStatusButtonTitleFont: UIFont = .preferredFont(forTextStyle: .body)
-        static let versionStatusButtonBackgroundColor = ColorPalette.mainYellow
+        static let versionStatusButtonUpdateTitleColor: UIColor = .black
+        static let versionStatusButtonLatestTitleColor: UIColor = .systemGray
+        static let versionStatusButtonUpdateBackgroundColor: UIColor = ColorPalette.mainYellow
+        static let versionStatusButtonLatestBackgroundColor: UIColor = .white
+    }
+    
+    enum Content {
+        static let versionInformationButtonUpdateTitle = "업데이트"
+        static let versionInformationButtonLatestTitle = "최신버전"
     }
 }

--- a/WhatWeEat/Presentation/Setting/View/VersionCell.swift
+++ b/WhatWeEat/Presentation/Setting/View/VersionCell.swift
@@ -1,0 +1,110 @@
+import UIKit
+import SwiftUI
+
+class VersionCell: UITableViewCell {
+    // MARK: - Properties
+    private let containerStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        return stackView
+    }()
+    private let titleStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .left
+        label.font = Design.titleLabelFont
+        label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
+        return label
+    }()
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .left
+        label.font = Design.subtitleLabelFont
+        label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
+        label.textColor = Design.subtilteLabelTextColor
+        return label
+    }()
+    private let versionStatusButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.layer.cornerRadius = 5
+        button.backgroundColor = Design.versionStatusButtonBackgroundColor
+        button.setTitleColor(Design.versionStatusButtonTitleColor, for: .normal)
+        button.titleLabel?.font = Design.versionStatusButtonTitleFont
+        return button
+    }()
+    
+    // MARK: - Initializers
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - LifeCycle Methods
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+        subtitleLabel.text = nil
+        versionStatusButton.setTitle(nil, for: .normal)
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+//        self.backgroundColor = ColorPalette.subYellow
+    }
+    
+    // MARK: - Methods
+    func apply(title: String, subtitle: String, buttonTitle: String) {
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+        versionStatusButton.setTitle(buttonTitle, for: .normal)
+    }
+    
+    private func configureUI() {
+        addSubview(containerStackView)
+        containerStackView.addArrangedSubview(titleStackView)
+        containerStackView.addArrangedSubview(versionStatusButton)
+        titleStackView.addArrangedSubview(titleLabel)
+        titleStackView.addArrangedSubview(subtitleLabel)
+        
+        NSLayoutConstraint.activate([
+            containerStackView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor, constant: 5),
+            containerStackView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: 30),
+            containerStackView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            containerStackView.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -5),
+        ])
+    }
+}
+
+// MARK: - NameSpace
+extension VersionCell {
+    private enum Design {
+        static let titleLabelFont: UIFont = .preferredFont(forTextStyle: .title3)
+        
+        static let subtitleLabelFont: UIFont = .preferredFont(forTextStyle: .body)
+        static let subtilteLabelTextColor: UIColor = .systemGray
+        
+        static let versionStatusButtonTitleColor: UIColor = .black
+        static let versionStatusButtonTitleFont: UIFont = .preferredFont(forTextStyle: .body)
+        static let versionStatusButtonBackgroundColor = ColorPalette.mainYellow
+    }
+}

--- a/WhatWeEat/Presentation/Setting/ViewModel/SettingDetailViewModel.swift
+++ b/WhatWeEat/Presentation/Setting/ViewModel/SettingDetailViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+import RxSwift
+
+final class SettingDetailViewModel {
+    // MARK: - Nested Types
+    struct Input {
+        let backButtonDidTap: Observable<Void>
+    }
+    
+    // MARK: - Properties
+    private let actions: SettingDetailViewModelAction!
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Initializers
+    init(actions: SettingDetailViewModelAction) {
+        self.actions = actions
+    }
+    
+    // MARK: - Methods
+    func transform(_ input: Input) {
+        configurebackButtonDidTapObservable(with: input.backButtonDidTap)
+    }
+    
+    private func configurebackButtonDidTapObservable(with inputObserver: Observable<Void>) {
+        inputObserver
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                self?.actions.popCurrentPage()
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/WhatWeEat/Presentation/Setting/ViewModel/SettingDetailViewModelAction.swift
+++ b/WhatWeEat/Presentation/Setting/ViewModel/SettingDetailViewModelAction.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct SettingDetailViewModelAction {
+    let popCurrentPage: () -> Void
+}

--- a/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -34,6 +34,7 @@ final class SettingViewModel {
     
     // MARK: - Properties
     private var actions: SettingViewModelAction!
+    private var settingItems: [SettingItem] = []
     private let disposeBag = DisposeBag()
     
     // MARK: - Initializers
@@ -88,11 +89,11 @@ final class SettingViewModel {
                     subtitle: self.configureVersionInformationSubtitle(),
                     buttonTitle: self.configureVersionInformationButtonUpdateTitle()
                 )
-                let settingItems: [SettingItem] = [
+                self.settingItems = [
                     editDislikedFoods, privacyPolicies, openSourceLicense, feedBackToDeveloper, recommendToFriend, versionInformation
                 ]
                 
-                return Observable.just(settingItems)
+                return Observable.just(self.settingItems)
             }
     }
     
@@ -145,12 +146,20 @@ final class SettingViewModel {
     private func configureSettingItemDidSelectObservable(with inputObserver: Observable<IndexPath>) {
         inputObserver
             .subscribe(onNext: { [weak self] indexPath in
-                guard let sectionKind = SettingViewController.SectionKind(rawValue: indexPath.section) else { return }
+                guard
+                    let sectionKind = SettingViewController.SectionKind(rawValue: indexPath.section),
+                    let self = self
+                else { return }
+                
                 switch sectionKind {
                 case .dislikedFood:
-                    self?.actions.showDislikedFoodSurveyPage()
+                    self.actions.showDislikedFoodSurveyPage()
                 case .ordinary:
-                    print("!!!")
+                    guard
+                        let ordinarySettingItems = self.settingItems.filter({ $0.sectionKind == .ordinary }) as? [OrdinarySettingItem],
+                        let content = ordinarySettingItems[indexPath.row].content
+                    else { return }
+                    self.actions.showSettingDetailPage(ordinarySettingItems[indexPath.row].title, content)
                 case .version:
                     return
                 }
@@ -165,11 +174,55 @@ extension SettingViewModel {
         static let editDislikedFoodsTitle = "못먹는 음식 수정하기"
         static let editDislikedFoodsContent = ""
         static let privacyPoliciesTitle = "개인정보 처리방침"
-        static let privacyPoliciesContent = ""
+        static let privacyPoliciesContent = """
+        개인정보 처리방침입니다.
+        """
         static let openSourceLicenseTitle = "오픈소스 라이센스"
-        static let openSourceLicenseContent = ""
+        static let openSourceLicenseContent = """
+        Rx for iOS
+        https://github.com/ReactiveX/RxSwift
+        Apache License Version 6.5.0
+
+        Realm Swift
+        https://github.com/realm/realm-swift
+        Apache License Version 10.26.0
+        
+        Rx for iOS
+        https://github.com/ReactiveX/RxSwift
+        Apache License Version 6.5.0
+
+        Realm Swift
+        https://github.com/realm/realm-swift
+        Apache License Version 10.26.0
+        
+        Rx for iOS
+        https://github.com/ReactiveX/RxSwift
+        Apache License Version 6.5.0
+
+        Realm Swift
+        https://github.com/realm/realm-swift
+        Apache License Version 10.26.0
+
+        Rx for iOS
+        https://github.com/ReactiveX/RxSwift
+        Apache License Version 6.5.0
+
+        Realm Swift
+        https://github.com/realm/realm-swift
+        Apache License Version 10.26.0
+
+        Rx for iOS
+        https://github.com/ReactiveX/RxSwift
+        Apache License Version 6.5.0
+
+        Realm Swift
+        https://github.com/realm/realm-swift
+        Apache License Version 10.26.0
+        """
         static let feedBackToDeveloperTitle = "개발자에게 피드백하기"
-        static let feedBackToDeveloperContent = ""
+        static let feedBackToDeveloperContent = """
+        개발자 이메일: aaaa@gmail.com
+        """
         static let recommendToFriendTitle = "친구에게 추천하기"
         static let recommendToFriendContent = ""
         static let versionInformationTitle = "버전 정보"

--- a/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -1,0 +1,102 @@
+import Foundation
+import RxSwift
+
+protocol SettingItem {
+    var title: String { get }
+    var sectionKind: SettingViewController.SectionKind { get }
+}
+
+final class SettingViewModel {
+    // MARK: - NestedTypes
+    struct Input {
+        let invokedViewDidLoad: Observable<Void>
+        let backButtonDidTap: Observable<Void>
+    }
+    
+    struct Output {
+        let tableViewItems: Observable<[SettingItem]>
+        let backButtonDidTap: Observable<Void>
+    }
+    
+    struct OrdinarySettingItem: SettingItem {
+        let title: String
+        let content: String?
+        let sectionKind: SettingViewController.SectionKind
+    }
+    
+    struct VersionSettingItem: SettingItem {
+        let title: String
+        let subtitle: String
+        let buttonTitle: String
+        let sectionKind: SettingViewController.SectionKind = .version
+    }
+    
+    func transform(_ input: Input) -> Output {
+        let tableViewItems = configureTableViewItems(with: input.invokedViewDidLoad)
+        let ouput = Output(tableViewItems: tableViewItems, backButtonDidTap: input.backButtonDidTap)
+        
+        return ouput
+    }
+    
+    private func configureTableViewItems(with inputObserver: Observable<Void>) -> Observable<[SettingItem]> {
+        inputObserver
+            .flatMap { () -> Observable<[SettingItem]> in
+                let editDislikedFoods = OrdinarySettingItem(
+                    title: Content.editDislikedFoodsTitle,
+                    content: Content.editDislikedFoodsContent,
+                    sectionKind: .dislikedFood
+                )
+                let privacyPolicies = OrdinarySettingItem(
+                    title: Content.privacyPoliciesTitle,
+                    content: Content.privacyPoliciesContent,
+                    sectionKind: .ordinarySetting
+                )
+                let openSourceLicense = OrdinarySettingItem(
+                    title: Content.openSourceLicenseTitle,
+                    content: Content.openSourceLicenseContent,
+                    sectionKind: .ordinarySetting
+                )
+                let feedBackToDeveloper = OrdinarySettingItem(
+                    title: Content.feedBackToDeveloperTitle,
+                    content: Content.feedBackToDeveloperContent,
+                    sectionKind: .ordinarySetting
+                )
+                let recommendToFriend = OrdinarySettingItem(
+                    title: Content.recommendToFriendTitle,
+                    content: Content.recommendToFriendContent,
+                    sectionKind: .ordinarySetting
+                )
+                let versionInformation = VersionSettingItem(
+                    title: Content.versionInformationTitle,
+                    subtitle: Content.versionInformationSubtitle,
+                    buttonTitle: Content.versionInformationButtonLatestTitle
+                )
+                let settingItems: [SettingItem] = [
+                    editDislikedFoods, privacyPolicies, openSourceLicense, feedBackToDeveloper, recommendToFriend, versionInformation
+                ]
+                
+                return Observable.just(settingItems)
+            }
+    }
+}
+
+// MARK: - NameSpaces
+extension SettingViewModel {
+    enum Content {
+        static let editDislikedFoodsTitle = "못먹는 음식 수정하기"
+        static let editDislikedFoodsContent = ""
+        static let privacyPoliciesTitle = "개인정보 처리방침"
+        static let privacyPoliciesContent = ""
+        static let openSourceLicenseTitle = "오픈소스 라이센스"
+        static let openSourceLicenseContent = ""
+        static let feedBackToDeveloperTitle = "개발자에게 피드백하기"
+        static let feedBackToDeveloperContent = ""
+        static let recommendToFriendTitle = "친구에게 추천하기"
+        static let recommendToFriendContent = ""
+        static let versionInformationTitle = "버전 정보"
+        static let versionInformationSubtitle = "현재 1.0 / 최신 1.0"
+        static let versionInformationButtonUpdateTitle = "업데이트"
+        static let versionInformationButtonLatestTitle = "최신버전"
+    }
+}
+

--- a/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModelAction.swift
+++ b/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModelAction.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct SettingViewModelAction {
+    let showDislikedFoodSurveyPage: () -> Void
+}

--- a/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModelAction.swift
+++ b/WhatWeEat/Presentation/Setting/ViewModel/SettingViewModelAction.swift
@@ -2,4 +2,5 @@ import Foundation
 
 struct SettingViewModelAction {
     let showDislikedFoodSurveyPage: () -> Void
+    let showSettingDetailPage: (String, String) -> Void
 }


### PR DESCRIPTION
# 배경
사용자가 못먹는 음식 리스트를 수정하고, App에 대한 다양한 정보를 확인할 수 있도록 하기 위해 `설정` 화면을 구현했습니다. 

`탭바`를 사용하는 대부분의 상용앱은 `마이페이지 탭`이 있는데, 우리뭐먹지 앱 기능상 사용자 개인정보를 처리하지 않으므로 마이페이지가 없고, 설정 화면에서는 부차적인 기능만 수행하므로 별도 탭을 만들지 않고 NavigationBar에서 접근하도록 구현했습니다.

# 작업 내용
## 1. UITableView를 통한 설정 화면 리스트 구현
설정화면의 경우 항상 List로 구성이 된다고 판단했습니다. 따라서 `CollectionView`가 아닌 `TableView`를 활용해 설정 페이지를 만들었습니다. Version Update를 위한 Cell은 구성이 달랐기에 `VersionCell`과 일반적인 `SettingCell`을 구분했습니다. 

또한 설정의 목록은 고정적이므로 Diffable DataSource를 사용하지 않았습니다.

## 2. 3개 Section으로 구분하고, 2개의 Cell Type을 활용
Section은 `dislikedFood`, `ordinary`, `version` 3가지로 구분했습니다. 
이처럼 TableView에 여러 개의 Section이 있는 경우 viewModelData.bind(to: tableView.rx.items) 형태로 binding이 불가능하여, UITableViewDataSource 메서드를 사용했습니다. 

또한 설정 화면에 필요한 Item의 경우 `SettingItem` 프로토콜을 준수하는 `OrdinarySettingItem`과 `VersionSettingItem`을 두어 `SettingViewModel`이 가지고 있도록 했습니다. 

이후 rx를 통해 SettingItem을 전달받아, UITableViewDataSource 메서드를 사용하여 TableView를 구성했습니다.

## 3. Delegate 패턴으로 버전정보의 `업데이트` 버튼의 탭 이벤트를 처리
사용자의 버전정보와 앱의 최신버전을 비교하여 업데이트가 가능한 경우 버튼 타이틀을 `업데이트`로, 업데이트가 불가한 경우 `최신버전`으로 표시했습니다.
이때 Cell의 delegate를 ViewController로 설정하여 탭 이벤트를 처리하도록 구현했습니다. 향후 AppStore 앱으로 이동시키도록 구현할 예정입니다.

## 4. `못먹는음식 수정하기` 화면을 띄울 때 realm 데이터 반영
OnbarodingPage에서 표시한 못먹는 음식을 `설정`에서 수정할 수 있는 기능을 구현했습니다. 코드 재사용을 위해 기존의 `configureDislikedFoods` 메서드를 리팩토링하여 못먹는음식 정보를 표시할 때, 먼저 realm 데이터를 받아와서 반영하도록 했습니다.
또한 `RealmManager` 타입에 CRUD 메서드 일부를 추가하여 ViewModel에서 이를 호출하도록 했습니다.

이외에도 UX를 고려하여 OnbarodingPage에서 못먹는음식 화면의 확인 버튼을 탭해야 앱의 최초실행 여부를 나타내는 `isFirstLaunched`가 false가 되도록 기능을 변경했습니다.

## 5. '못먹는 음식 수정하기', '버전정보'를 제외한 다른 리스트에 대한 DetailView 구현
설정의 다른 리스트들의 경우 Text만 올라가면 됐기 때문에, 셀을 선택하면 `TextView`를 가지고 있는 `SettingDetailViewController`를 띄워주도록 했습니다. 

사용자가 수정할 수 없도록 `isEditable` 프로퍼티를 `false`로 했으며, `TextView`가 `SettingDetailViewController`의 View에 가득차도록 했습니다. 

# 테스트 방법
버전 정보확인의 경우 추후 `ViewModel UnitTest`를 통해 검증할 예정입니다. 
(이미 시뮬레이터를 통해 정상 동작하는 것은 확인했습니다.)

# 리뷰 노트
- 향후 버전정보의 `업데이트` 버튼을 탭하면, AppStore 앱으로 이동시켜 사용자가 앱을 업데이트할 수 있도록 구현할 예정입니다.
- 향후 `친구에게 추천하기` 버튼을 탭하면, 앱 다운로드 링크를 복사하거나, SNS 공유 등을 통해 링크를 전달하는 기능을 구현할 예정입니다.
- 향후 개인정보 처리방침, 오픈소스 라이센스, 개발자에게 피드백하기의 경우 Text를 수정할 예정입니다.

# 스크린샷
<img src="https://user-images.githubusercontent.com/70856586/172523548-f3092c8c-fd3e-429a-a2dd-479b831672de.gif" width="250">
